### PR TITLE
add dirty check for leaving dashboard page if unsaved

### DIFF
--- a/app/assets/javascripts/angular/controllers/dashboard_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/dashboard_ctrl.js
@@ -1,9 +1,17 @@
-angular.module("Prometheus.controllers").controller('DashboardCtrl', function($scope, $http, $timeout, $document) {
+angular.module("Prometheus.controllers").controller('DashboardCtrl', function($scope, $window, $http, $timeout, $document) {
+  $window.onbeforeunload = function() {
+    var message = 'You have some unsaved changes!';
+    var unsavedChanges = angular.toJson(angular.copy($scope.graphs)) !== angular.toJson(originalGraphs);
+    if (unsavedChanges) {
+      return message;
+    }
+  }
   $scope.globalConfig = dashboardData.globalConfig || {
     numColumns: 2,
     endTime: null
   };
   $scope.graphs = dashboardData.graphs || [];
+  var originalGraphs = angular.copy($scope.graphs);
   $scope.servers = servers;
   $scope.fullscreen = false;
   $scope.saving = false;
@@ -35,6 +43,8 @@ angular.module("Prometheus.controllers").controller('DashboardCtrl', function($s
       }
     }).error(function(data, status) {
       alert("Error saving dashboard.");
+    }).success(function() {
+      originalGraphs = angular.copy($scope.graphs);
     }).always(function() {
       $scope.saving = false;
     });

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -87,5 +87,6 @@
 }
 
 .sortable-graphs {
+  list-style-type: none;
   padding: 10px;
 }


### PR DESCRIPTION
this checks to see if there are unsaved changes.

the original state of the graphs is saved, and whenever you save successfully that state is updated. if you have unsaved changes, `$scope.graphs` and `original_graphs` will be out of sync and will prompt you.
