### PR TITLE
Fix server selection and widget removal.

### DIFF
--- a/app/assets/javascripts/angular/controllers/dashboard_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/dashboard_ctrl.js
@@ -119,6 +119,10 @@ angular.module("Prometheus.controllers").controller('DashboardCtrl', function($s
     return 'col-lg-' + colMap[$scope.globalConfig.numColumns];
   };
 
+  $scope.$on('removeWidget', function(ev, index) {
+    $scope.widgets.splice(index, 1);
+  });
+
   $scope.addGraph = function() {
     $scope.widgets.push(Prometheus.Graph.getGraphDefaults());
   };

--- a/app/assets/javascripts/angular/controllers/frame_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/frame_ctrl.js
@@ -2,8 +2,8 @@ angular.module("Prometheus.controllers").controller('FrameCtrl', ["$scope", func
   // Appended to frame source URL to trigger refresh.
   $scope.refreshCounter = 0;
 
-  $scope.removeFrame = function(idx) {
-    $scope.widgets.splice(idx, 1);
+  $scope.removeFrame = function() {
+    $scope.$emit('removeWidget', $scope.index);
   };
 
   $scope.toggleTab = function(tab) {

--- a/app/assets/javascripts/angular/controllers/graph_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/graph_ctrl.js
@@ -12,8 +12,8 @@ angular.module("Prometheus.controllers").controller('GraphCtrl', ["$scope", "$ht
   $scope.requestsInFlight = 0;
   $scope.data = null;
 
-  $scope.removeGraph = function(idx) {
-    $scope.widgets.splice(idx, 1);
+  $scope.removeGraph = function() {
+    $scope.$emit('removeWidget', $scope.index);
   };
 
   $scope.toggleTab = function(tab) {

--- a/app/assets/javascripts/angular/directives/frame.js
+++ b/app/assets/javascripts/angular/directives/frame.js
@@ -1,7 +1,8 @@
 angular.module("Prometheus.directives").directive('inlineFrame', function() {
   return {
     scope: {
-      frame: "=frameSettings"
+      frame: "=frameSettings",
+      index: "="
     },
     restrict: "AE",
     templateUrl: "/frame_template.html"

--- a/app/assets/javascripts/angular/directives/graph.js
+++ b/app/assets/javascripts/angular/directives/graph.js
@@ -3,7 +3,8 @@ angular.module("Prometheus.directives").directive('graph', function() {
     scope: {
       graph: "=graphSettings",
       servers: "=servers",
-      globalEndTime: "=globalEndTime"
+      globalEndTime: "=globalEndTime",
+      index: "="
     },
     restrict: "AE",
     templateUrl: "/graph_template.html"

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -91,10 +91,10 @@
       <li ng-repeat="widget in widgets" ng-class="[columnClass(), 'widget_column']">
         <span ng-switch="widget.type">
           <span ng-switch-when="graph">
-            <graph graph-settings="widget" servers="servers" global-end-time="globalConfig.endTime">
+            <graph graph-settings="widget" servers="servers" global-end-time="globalConfig.endTime" index="$index">
           </span>
           <span ng-switch-when="frame">
-            <inline-frame frame-settings="widget">
+            <inline-frame frame-settings="widget" index="$index">
           </span>
         </span>
       </li>

--- a/public/frame_template.html
+++ b/public/frame_template.html
@@ -2,7 +2,7 @@
   <div class="widget_wrapper panel panel-default pull-left" ng-mouseenter="showControls = true" ng-mouseleave="showControls = false">
     <div class="widget_title panel-heading">
       {{getTitle()}}
-      <div class="btn btn-danger btn-xs remove_graph_btn pull-right" ng-click="removeFrame($index)" ng-show="showControls">
+      <div class="btn btn-danger btn-xs remove_graph_btn pull-right" ng-click="removeFrame()" ng-show="showControls">
         <i title="Remove graph" class="icon-cross"></i>
       </div>
     </div>

--- a/public/graph_template.html
+++ b/public/graph_template.html
@@ -6,7 +6,7 @@
         <img src="/assets/spinner.gif" alt="AJAX indicator">
         {{requestsInFlight}} pending
       </span>
-      <div class="btn btn-danger btn-xs remove_graph_btn pull-right" ng-click="removeGraph($index)" ng-show="showControls">
+      <div class="btn btn-danger btn-xs remove_graph_btn pull-right" ng-click="removeGraph()" ng-show="showControls">
         <i title="Remove graph" class="icon-cross"></i>
       </div>
     </div>


### PR DESCRIPTION
I accidentally broke server selection in my graph/frame-widget PR by not passing in the raw `servers` array (only `serversById`) into the `graph` directive anymore... I decided to now simply pass in `servers` to the directive instead and do the generation of `serversById` separately in each graph scope. Yes, this uses a tiny bit more memory, but seems to encapsulate its usage a bit better.

In the graph controller, I decided to not use a `$watch` to recalculate `serversById`, but just do it once in the beginning: when I used a `$watch`, it would trigger the recomputation too late (after `refreshGraph`, where the result is already needed), and also, the `servers` list cannot currently change without reloading the entire page, so it should be fine to compute it only once.

Edit: Other missing scope variables were the list `$index` and the `widgets` list, which were used by a widget to remove itself from the global list. Instead, I now only pass in `$index` into the widget directive and the directive emits a removal event for itself, which the dashboard controllor handles.
