### PR TITLE
Fix global refresh text color

### DIFF
--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -126,6 +126,13 @@
       }
     }
 
+    .dropdown-menu li a {
+      color: $dark-text;
+      &:hover {
+        background-color: $dark-accent;
+      }
+    }
+
     .btn-primary {
       background-color: $dark-accent;
       border-color: #89486d;


### PR DESCRIPTION
Global refresh text color was not being updated when switching to the dark color theme. This adds the css to make that drop down in line with the other elements in the dark theme.
