### PR TITLE
Don't pass in entire global config just for the aspect ratio.

### DIFF
--- a/app/assets/javascripts/angular/directives/graph.js.erb
+++ b/app/assets/javascripts/angular/directives/graph.js.erb
@@ -2,9 +2,9 @@ angular.module("Prometheus.directives").directive('graph', function() {
   return {
     scope: {
       graph: "=graphSettings",
-      servers: "=servers",
-      globalEndTime: "=globalEndTime",
-      globalConfig: "=globalConfig",
+      servers: "=",
+      globalEndTime: "=",
+      aspectRatio: "=",
       frameHeight: "&",
       index: "="
     },

--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -2,7 +2,7 @@ angular.module("Prometheus.directives").directive('graphChart', function(WidgetH
   return {
     scope: {
       graphSettings: '=',
-      globalConfig: '=',
+      aspectRatio: '=',
       graphData: '='
     },
     link: function(scope, element, attrs) {
@@ -73,7 +73,7 @@ angular.module("Prometheus.directives").directive('graphChart', function(WidgetH
 
       function redrawGraph() {
         // graph height is being set irrespective of legend
-        var graphHeight = WidgetHeightCalculator(element[0], scope.globalConfig.aspectRatio);
+        var graphHeight = WidgetHeightCalculator(element[0], scope.aspectRatio);
         $(element[0]).css('height', graphHeight);
 
         if (scope.graphData == null) {
@@ -203,5 +203,3 @@ angular.module("Prometheus.directives").directive('graphChart', function(WidgetH
     },
   };
 });
-
-

--- a/app/assets/templates/graph_template.html.erb
+++ b/app/assets/templates/graph_template.html.erb
@@ -183,7 +183,7 @@
     </div>
 
     <div ng-click="showTab = null">
-      <div class="graph_chart" graph-chart graph-settings="graph" graph-data="data" global-config="globalConfig">
+      <div class="graph_chart" graph-chart graph-settings="graph" graph-data="data" aspect-ratio="aspectRatio">
         <div class="legend"></div>
       </div>
     </div>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -79,7 +79,7 @@
           <label>Aspect Ratio:
             <select class="form-control" type="text"
               ng-model="globalConfig.aspectRatio"
-              ng-change="redrawGraphs()"
+              ng-change="nextCycleRedraw()"
               ng-options="r.value as r.fraction for r in aspectRatios">
             </select>
           </label>
@@ -109,7 +109,7 @@
               graph-settings="widget"
               servers="servers"
               global-end-time="globalConfig.endTime"
-              global-config="globalConfig"
+              aspect-ratio="globalConfig.aspectRatio"
               index="$index"
               frame-height="frameHeight()">
           </span>


### PR DESCRIPTION
Passing in the entire globalConfig object from the parent scope makes the graph
widget less reusable (closely tied to the structure of that global config) and
also makes it less clear what the graph really needs from it.

Since the aspect ratio is now passed as a copy through multiple scope
layers (dashboard -> graph -> graph_chart), we need to redraw the graphs
only after the corresponding Angular cycle has completely, so instead of
calling `redrawGraphs` when changing the ratio select, I call
`nextCycleRedraw` now.
