### PR TITLE
Remove wrapping from widget titles

### DIFF
--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -41,9 +41,11 @@
 }
 
 .widget_title {
+  cursor: move;
+  overflow: hidden;
   position: relative;
   text-align: center;
-  cursor: move;
+  white-space: nowrap;
 }
 
 .graph_ajax_status {


### PR DESCRIPTION
Long widget titles no longer wrap to the next line. Their overflow remains on the same line, hidden.

![screen shot 2014-01-24 at 7 34 55 pm](https://f.cloud.github.com/assets/1398104/2000396/dc4a97b0-8558-11e3-9d3c-ec5c70f5ecdb.png)
