### PR TITLE
Use DATABASE_URL only instead of database.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ADD        . /promdash
 RUN        bundle install --without="development test migration" && \
            bundle exec rake assets:precompile
 RUN        printf '#!/bin/sh\n \
-           [ -z "$DATABASE_URL" ] && \
-           export DATABASE_URL=$(echo $DB_PORT_3306_TCP|sed 's/^tcp/mysql2/')/$PROMDASH_MYSQL_DATABASE\nexec $@' > \
-           run && chmod a+x run
+           [ -z "$DATABASE_URL" ] && { echo "DATABASE_URL not set"; exit 1; }\n \
+           export DB_HOST=$(echo $DB_PORT_3306_TCP|sed "s|^tcp://||")\n \
+           export DATABASE_URL=$(echo "$DATABASE_URL" | sed "s/\[HOST\]/$DB_HOST/")\n \
+           exec $@\n' > run && chmod a+x run
 EXPOSE     3000


### PR DESCRIPTION
This makes the Dockerfile set DATABASE_URL instead of mixing it with
database.yaml which apparently doesn't work.
We choose to use DATABASE_URL over database.yaml because it's much
easier to configure/customize this in docker and similiar environments.

You can create the database by:

```
$ docker run -t -i -link mysqld:db \
   DATABASE_URL="mysql2://<user>:<pass>@[HOST]/<db>" \
   rake db:setup
```

(You can also set DATABASE_URL if you can use docker links)

Now you can run promdash like this:

```
$ docker run -t -i -link mysqld:db \
   DATABASE_URL="mysql2://<user>:<pass>@[HOST]/<db>" \
   -p 3000 promdash
```

[HOST] gets replaced by ip:host of the linked container.
