### PR TITLE
Fix Embedded View Multi-render

### DIFF
--- a/app/views/layouts/single_widget.html.erb
+++ b/app/views/layouts/single_widget.html.erb
@@ -5,11 +5,6 @@
     <title><%= content_for?(:title) ? yield(:title) : "Prometheus Dashboard" %></title>
     <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "Prometheus, yo." %>">
 
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
-
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.7/angular.min.js"></script>
-
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>


### PR DESCRIPTION
The embedded view was drawing too many graphs. When javascript testing was added, circumstances required that angular, jquery, and jquery-ui be vendored and added to application.js. The main layout had its script tags for these files removed, but the single widget layout (which is used for both single widget and embedded views) was not updated.

fixes #81 
