### PR TITLE
Fix initial double-load.

### DIFF
--- a/app/assets/javascripts/angular/controllers/graph_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/graph_ctrl.js
@@ -109,6 +109,4 @@ angular.module("Prometheus.controllers").controller('GraphCtrl', ["$scope", "$ht
   if ($scope.graph.axes.length == 0) {
     $scope.addAxis();
   }
-
-  $scope.refreshGraph();
 }]);


### PR DESCRIPTION
https://github.com/prometheus/promdash/issues/51 popped up again because
the initial double reload was readded as part of a048c9a.
