### PR TITLE
Shorter embed urls

### DIFF
--- a/app/assets/javascripts/angular/controllers/graph_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/graph_ctrl.js
@@ -1,15 +1,19 @@
-angular.module("Prometheus.controllers").controller('GraphCtrl', ["$scope", "$http", "$window", "VariableInterpolator", "UrlHashEncoder", "GraphRefresher", "InputHighlighter", "ServersByIdObject", function($scope, $http, $window, VariableInterpolator, UrlHashEncoder, GraphRefresher, InputHighlighter, ServersByIdObject) {
+angular.module("Prometheus.controllers").controller('GraphCtrl', ["$scope", "$http", "$window", "VariableInterpolator", "UrlHashEncoder", "GraphRefresher", "InputHighlighter", "ServersByIdObject", "WidgetLinkHelper", function($scope, $http, $window, VariableInterpolator, UrlHashEncoder, GraphRefresher, InputHighlighter, ServersByIdObject, WidgetLinkHelper) {
   $scope.generateWidgetLink = function(event) {
+    if ($scope.showTab !== 'staticlink') {
+      return;
+    }
     var graphBlob = {};
     graphBlob.widget = $scope.graph;
     graphBlob.globalConfig = dashboardData.globalConfig;
-    $scope.widgetLink = location.origin + "/widget##" + UrlHashEncoder(graphBlob);
-
-    if (event) {
-      // TODO: find more robust means of accessing the corresponding input field.
-      var input = event.currentTarget.parentElement.parentElement.querySelector("[ng-model=widgetLink]")
-      InputHighlighter(input);
-    }
+    WidgetLinkHelper
+      .createLink({
+         encoded_url: UrlHashEncoder(graphBlob),
+         graph_title: $scope.graph.title,
+         dashboard_name: dashboardName
+       }, event)
+      .setLink($scope)
+      .highlightInput(event);
   };
 
   $scope.graph.legendSetting = $scope.graph.legendSetting || "sometimes";

--- a/app/assets/javascripts/angular/controllers/single_widget_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/single_widget_ctrl.js
@@ -1,5 +1,5 @@
 angular.module("Prometheus.controllers").controller('SingleWidgetCtrl', ["$window", "$timeout", "$scope", "$http", "UrlConfigDecoder", "VariableInterpolator", "GraphRefresher", "WidgetHeightCalculator", "ServersByIdObject", "FullScreenAspectRatio", "ThemeManager", function($window, $timeout, $scope, $http, UrlConfigDecoder, VariableInterpolator, GraphRefresher, WidgetHeightCalculator, ServersByIdObject, FullScreenAspectRatio, ThemeManager) {
-  var graphBlob = UrlConfigDecoder();
+  var graphBlob = UrlConfigDecoder(blob);
   $scope.widget = graphBlob.widget;
   $scope.servers = servers;
   $scope.serversById = ServersByIdObject($scope.servers);

--- a/app/assets/javascripts/angular/services/input_highlighter.js
+++ b/app/assets/javascripts/angular/services/input_highlighter.js
@@ -3,6 +3,6 @@ angular.module("Prometheus.services").factory('InputHighlighter', ["$timeout", f
     $timeout(function() {
       input.focus();
       input.setSelectionRange(0, input.value.length);
-    }, 0);
+    }, 50);
   };
 }]);

--- a/app/assets/javascripts/angular/services/url_config.js
+++ b/app/assets/javascripts/angular/services/url_config.js
@@ -1,6 +1,6 @@
 angular.module("Prometheus.services").factory('UrlConfigDecoder', function($location) {
-  return function() {
-    var hash = $location.hash();
+  return function(defaultHash) {
+    var hash = $location.hash() || defaultHash;
     if (!hash) {
       return {};
     }

--- a/app/assets/javascripts/angular/services/widget_link_helper.js
+++ b/app/assets/javascripts/angular/services/widget_link_helper.js
@@ -1,0 +1,27 @@
+angular.module("Prometheus.services").factory('WidgetLinkHelper', ["$http", "InputHighlighter", function($http, InputHighlighter) {
+  return {
+    createLink: function(data) {
+      this.promise = $http.post('/w', data);
+      return this;
+    },
+    setLink: function(scope) {
+      if (!this.promise) {
+        return;
+      }
+      this.promise.then(function(payload) {
+        scope.widgetLink = location.origin + "/w/" + payload.data.id;
+      });
+      this.promise = null;
+      return this;
+    },
+    highlightInput: function(event) {
+      if (!event) {
+        return;
+      }
+
+      // TODO: find more robust means of accessing the corresponding input field.
+      var input = event.currentTarget.parentElement.parentElement.querySelector("[ng-model=widgetLink]")
+      InputHighlighter(input);
+    }
+  };
+}]);

--- a/app/controllers/single_widget_controller.rb
+++ b/app/controllers/single_widget_controller.rb
@@ -2,7 +2,15 @@ class SingleWidgetController < ApplicationController
   after_action :allow_iframe, only: :show
 
   def show
+    shortened_url = ShortenedUrl.find_by_slug(params[:slug])
+    shortened_url.update_last_accessed
+    @blob = shortened_url.encoded_url
     @servers = Server.all
     render layout: 'single_widget'
+  end
+
+  def create
+    shortened_url = ShortenedUrl.create_with_last_accessed params
+    render json: {id: shortened_url.slug}
   end
 end

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -1,3 +1,5 @@
+require 'slug_maker'
+
 class Dashboard < ActiveRecord::Base
   validates :name, uniqueness: { case_sensitive: false }
   validates :name, :slug, presence: true
@@ -21,10 +23,10 @@ class Dashboard < ActiveRecord::Base
   end
 
   def black_listed_slug_names
-    %w(dashboard servers about help signin signout home contact assets widget)
+    %w(dashboard servers about help signin signout home contact assets w)
   end
 
   def create_slug
-    self.slug = name.downcase.gsub(' ','-').gsub(/[^a-zA-Z0-9-]/, '')
+    self.slug = SlugMaker.slug(name)
   end
 end

--- a/app/models/shortened_url.rb
+++ b/app/models/shortened_url.rb
@@ -1,0 +1,18 @@
+require 'slug_maker'
+
+class ShortenedUrl < ActiveRecord::Base
+  def self.create_with_last_accessed params
+    shortened_url = new encoded_url: params[:encoded_url], last_accessed: Time.now
+    shortened_url.save!
+    shortened_url.set_slug params[:dashboard_name], params[:graph_title]
+    shortened_url
+  end
+
+  def set_slug dashboard_name, graph_title
+    update_attribute :slug, SlugMaker.slug("#{id} #{dashboard_name} #{graph_title}")
+  end
+
+  def update_last_accessed
+    update_attribute :last_accessed, Time.now
+  end
+end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,5 +1,6 @@
 <script type="text/javascript">
   dashboardData = <%= @dashboard.dashboard_json ? @dashboard.dashboard_json.html_safe : '{}' %>;
+  dashboardName = "<%= @dashboard.name %>";
   servers = <%= @servers.to_json.html_safe %>;
 </script>
 

--- a/app/views/single_widget/show.html.erb
+++ b/app/views/single_widget/show.html.erb
@@ -1,5 +1,6 @@
 <script type="text/javascript">
   servers = <%= @servers.to_json.html_safe %>;
+  blob = "<%= @blob %>";
 </script>
 
 <div class="fullscreen">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ PrometheusDashboard::Application.routes.draw do
   resources :dashboards
   resources :servers
 
-  get '/widget', to: 'single_widget#show'
+  get '/w/:slug', to: 'single_widget#show'
+  post '/w', to: 'single_widget#create'
   get '/embed/:slug', to: 'embed#show'
   get '/:slug', to: 'dashboards#show', as: 'dashboard_slug'
   match '/:slug', to: 'dashboards#update', as: 'dashboard_slug_put', via: [:put, :patch]

--- a/db/migrate/20140325002512_add_url_shortened_table.rb
+++ b/db/migrate/20140325002512_add_url_shortened_table.rb
@@ -1,0 +1,9 @@
+class AddUrlShortenedTable < ActiveRecord::Migration
+  def change
+    create_table :shortened_urls do |t|
+      t.timestamps
+      t.string :encoded_url
+      t.timestamp :last_accessed
+    end
+  end
+end

--- a/db/migrate/20140325231352_add_slug_to_shortener.rb
+++ b/db/migrate/20140325231352_add_slug_to_shortener.rb
@@ -1,0 +1,5 @@
+class AddSlugToShortener < ActiveRecord::Migration
+  def change
+    add_column :shortened_urls, :slug, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131223124230) do
+ActiveRecord::Schema.define(version: 20140325231352) do
 
   create_table "dashboards", force: true do |t|
     t.string   "name"
@@ -26,6 +26,14 @@ ActiveRecord::Schema.define(version: 20131223124230) do
     t.string   "url"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "shortened_urls", force: true do |t|
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "encoded_url"
+    t.datetime "last_accessed"
+    t.string   "slug"
   end
 
 end

--- a/lib/slug_maker.rb
+++ b/lib/slug_maker.rb
@@ -1,0 +1,5 @@
+class SlugMaker
+  def self.slug(name)
+    name.downcase.gsub(' ','-').gsub(/[^a-zA-Z0-9-]/, '')
+  end
+end

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -19,15 +19,4 @@ describe Dashboard do
       expect(d).to_not be_valid
     end
   end
-
-  context "slug" do
-    it "makes the slug" do
-      d = Dashboard.new_with_slug(name: "Super Awesome Dashboard")
-      expect(d.slug).to eq("super-awesome-dashboard")
-    end
-    it "cleans the dashboard name to create the slug" do
-      d = Dashboard.new_with_slug(name: "U_ser's Awes(()ome Dashboard!!")
-      expect(d.slug).to eq("users-awesome-dashboard")
-    end
-  end
 end

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe ShortenedUrl do
+  describe "create_with_last_accessed" do
+    it "sets last accessed on creation" do
+      shortened_url = ShortenedUrl.create_with_last_accessed({encoded_url: "some_encoded_url"})
+      expect(shortened_url.last_accessed).to_not be_nil
+    end
+
+    it "persists in the database" do
+      expect {
+        ShortenedUrl.create_with_last_accessed({encoded_url: "some_encoded_url"})
+      }.to change { ShortenedUrl.count }.by 1
+    end
+  end
+end

--- a/spec/models/slug_maker_spec.rb
+++ b/spec/models/slug_maker_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+require "slug_maker"
+
+describe SlugMaker do
+  it "makes the slug" do
+    d = Dashboard.new_with_slug(name: "Super Awesome Dashboard")
+    expect(d.slug).to eq("super-awesome-dashboard")
+  end
+
+  it "cleans the dashboard name to create the slug" do
+    d = Dashboard.new_with_slug(name: "U_ser's Awes(()ome Dashboard!!")
+    expect(d.slug).to eq("users-awesome-dashboard")
+  end
+end


### PR DESCRIPTION
Store the encoded data in a table that is accessed from a url of format:
`http://promdash.com/widget/42-prometheus-health-stored-sample-rates`

where 42 is the `id` for the row entry, `Prometheus Health` is the dashboard name, and `Stored Sample Rates` is the graph title.

feature requested in #75 
