### PR TITLE
Iframe firefox styling

### DIFF
--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -94,6 +94,9 @@
   height: 100%;
   overflow: hidden;
   width: 100%;
+}
+
+.graphite_frame {
   background-color: #000000;
 }
 

--- a/app/assets/templates/frame_template.html
+++ b/app/assets/templates/frame_template.html
@@ -54,7 +54,7 @@
     </div>
 
     <div ng-style="frameHeight()">
-      <iframe ng-src="{{frameURL()}}" class="frame_iframe" marginwidth="0" scrolling="no"></iframe>
+      <iframe ng-src="{{frameURL()}}" class="frame_iframe" ng-class="{graphite_frame:frame.graphite}" marginwidth="0" scrolling="no"></iframe>
     </div>
   </div>
 </span>


### PR DESCRIPTION
Fixes #89, which is really bugging me since I use firefox now.

@stuartnelson3 You might want to have a look at my second commit. If we were having a graphite css class on graphite iframes, we could limit the background-color setting to these iframes.
