### PR TITLE
Negative Y-Values for Rickshaw

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -87,6 +87,7 @@ angular.module("Prometheus.directives").directive('graphChart', ["$location", "W
 
         rsGraph = new Rickshaw.Graph({
           element: element[0],
+          min: yMin(series),
           interpolation: scope.graphSettings.interpolationMethod,
           renderer: (scope.graphSettings.stacked ? 'stack' : 'line'),
           series: series
@@ -151,6 +152,17 @@ angular.module("Prometheus.directives").directive('graphChart', ["$location", "W
 
       function elementHeight($element) {
         return $element.outerHeight(true);
+      }
+
+      function yMin(series) {
+        var yValues = series.map(function(s) {
+          return s.data.map(function(d) {
+            return d.y;
+          });
+        });
+        var flatYValues = d3.merge(yValues);
+        var yMin = Math.min.apply(Math, flatYValues);
+        return yMin > 0 ? 0 : yMin;
       }
 
       function setLegendPresence(series) {


### PR DESCRIPTION
Add min: "auto" to the rickshaw graph options to tell rickshaw to set the graph minimum at the minimum for the data passed into the constructor. Rickshaw defaults to 0 without this.

Addresses #55 

Regarding #74: If the data points have already been normalized to be within 0.0 and 1.0, it is my assumption that Rickshaw will correctly render based on these values. Are the values coming in NOT normalized to be within 0 and 1? Doing a quick hack with a single series, when I divided the values by the max it was correctly scaled from 0.0 to 1.0 on the graph.

I guess that was a long way of saying, I believe that #74 is a data issue, not a rickshaw issue.
