### PR TITLE
Set dashboard name on embed page

### DIFF
--- a/app/views/embed/show.html.erb
+++ b/app/views/embed/show.html.erb
@@ -1,5 +1,6 @@
 <script type="text/javascript">
   dashboardData = <%= @dashboard.dashboard_json ? @dashboard.dashboard_json.html_safe : '{}' %>;
+  dashboardName = "<%= @dashboard.name %>";
   servers = <%= @servers.to_json.html_safe %>;
 </script>
 


### PR DESCRIPTION
Dashboard name wasn't set on the embed show page, so single widget urls couldn't be generated.
