### PR TITLE
Link to dashboard from widget

### DIFF
--- a/app/assets/javascripts/angular/controllers/graph_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/graph_ctrl.js
@@ -100,4 +100,8 @@ angular.module("Prometheus.controllers").controller('GraphCtrl', ["$scope", "$ht
   }
 
   $scope.refreshGraph();
+  if (location.pathname.match(/^\/w\//)) { // On a widget page.
+    $scope.widgetPage = true;
+    $scope.dashboard = dashboard;
+  }
 }]);

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -347,6 +347,11 @@ error-message {
   padding: 0;
 }
 
+.dashboard_link {
+  position: relative;
+  z-index: 1;
+}
+
 .graph_settings_image {
   background-repeat: no-repeat;
   background-size: 30px 13px;

--- a/app/assets/templates/graph_template.html.erb
+++ b/app/assets/templates/graph_template.html.erb
@@ -2,6 +2,7 @@
   <div class="widget_wrapper panel panel-default pull-left" ng-mouseenter="showControls = true" ng-mouseleave="showControls = false">
     <div class="js_widget_wrapper widget_title panel-heading">
       <error-message error-messages="errorMessages"></error-message>
+      <span ng-show="dashboard"><a href="/{{dashboard.slug}}" class="dashboard_link pointer">{{dashboard.name}}</a> &mdash; </span>
       {{title()}}
       <span class="graph_ajax_status pull-right" ng-show="requestsInFlight">
         <img src="<%= asset_path 'spinner.gif' %>" alt="AJAX indicator">
@@ -20,7 +21,7 @@
         <div class="btn btn-primary btn-sm" ng-click="toggleTab('graph')"><i title="Graph and axis settings" class="icon-line-graph"></i></div>
         <div class="btn btn-primary btn-sm" ng-click="toggleTab('palette')"><i title="Palette" class="icon-palette"></i></div>
         <div class="btn btn-primary btn-sm" ng-click="toggleTab('legend')"><i title="Legend Settings" class="icon-list"></i></div>
-        <div class="btn btn-primary btn-sm" ng-click="toggleTab('staticlink'); generateWidgetLink($event)"><i title="Link to Graph" class="icon-link"></i></div>
+        <div ng-hide="widgetPage" class="btn btn-primary btn-sm" ng-click="toggleTab('staticlink'); generateWidgetLink($event)"><i title="Link to Graph" class="icon-link"></i></div>
         <div class="btn btn-primary btn-sm" ng-click="refreshGraph()"><i title="Refresh" class="icon-cycle"></i></div>
       </div>
 

--- a/app/controllers/single_widget_controller.rb
+++ b/app/controllers/single_widget_controller.rb
@@ -6,13 +6,15 @@ class SingleWidgetController < ApplicationController
   def show
     shortened_url = ShortenedUrl.find(params[:slug])
     shortened_url.update_last_accessed
+    @dashboard = shortened_url.dashboard
     @blob = shortened_url.encoded_url
     @servers = Server.all
     render layout: 'single_widget'
   end
 
   def create
-    shortened_url = ShortenedUrl.create_from_encoded_url params[:encoded_url]
+    dashboard = Dashboard.find_by_name params[:dashboard_name]
+    shortened_url = dashboard.shortened_urls.create_from_encoded_url params[:encoded_url]
     payload = {
       id: SlugMaker.slug("#{shortened_url.id} #{params[:dashboard_name]} #{params[:graph_title]}")
     }

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -1,6 +1,7 @@
 require 'slug_maker'
 
 class Dashboard < ActiveRecord::Base
+  has_many :shortened_urls
   validates :name, uniqueness: { case_sensitive: false }
   validates :name, :slug, presence: true
   validate :acceptable_slug

--- a/app/models/shortened_url.rb
+++ b/app/models/shortened_url.rb
@@ -1,6 +1,7 @@
 require 'digest/md5'
 
 class ShortenedUrl < ActiveRecord::Base
+  belongs_to :dashboard
   def self.create_from_encoded_url encoded_url
     find_or_create_by!(checksum: checksum(encoded_url)) do |url|
       url.encoded_url = encoded_url

--- a/app/views/single_widget/show.html.erb
+++ b/app/views/single_widget/show.html.erb
@@ -1,5 +1,6 @@
 <script type="text/javascript">
   servers = <%= @servers.to_json.html_safe %>;
+  dashboard = <%= @dashboard.to_json.html_safe %>;
   blob = "<%= @blob %>";
 </script>
 

--- a/db/migrate/20140413155227_associate_shortened_url_and_dashboard.rb
+++ b/db/migrate/20140413155227_associate_shortened_url_and_dashboard.rb
@@ -1,0 +1,5 @@
+class AssociateShortenedUrlAndDashboard < ActiveRecord::Migration
+  def change
+    add_column :shortened_urls, :dashboard_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140331215234) do
+ActiveRecord::Schema.define(version: 20140413155227) do
 
   create_table "dashboards", force: true do |t|
     t.string   "name"
@@ -33,7 +33,8 @@ ActiveRecord::Schema.define(version: 20140331215234) do
     t.datetime "updated_at"
     t.text     "encoded_url"
     t.datetime "last_accessed"
-    t.string   "checksum",      limit: 32,  default: "", null: false
+    t.string   "checksum",      limit: 32, default: "", null: false
+    t.integer  "dashboard_id"
   end
 
   add_index "shortened_urls", ["checksum"], name: "index_shortened_urls_on_checksum", unique: true

--- a/spec/controllers/single_widget_controller_spec.rb
+++ b/spec/controllers/single_widget_controller_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe SingleWidgetController do
   before(:each) do
+    @dashboard = Dashboard.create name: "example dash", slug: "example-dash"
     @params = {
       encoded_url: "some_url",
       dashboard_name: "example dash",
@@ -11,8 +12,16 @@ describe SingleWidgetController do
   end
 
   describe "#show" do
-    it "assigns the graph data blob" do
+    it "doesn't blow up if there is no associated dashboard" do
       shortened_url = ShortenedUrl.create_from_encoded_url "some_url"
+      expect {
+        get :show, {slug: shortened_url.to_param}
+      }.to_not raise_error
+      expect(response).to be_success
+    end
+
+    it "assigns the graph data blob" do
+      shortened_url = @dashboard.shortened_urls.create_from_encoded_url "some_url"
       get :show, {slug: shortened_url.to_param}
       expect(assigns(:blob)).to eq(shortened_url.encoded_url)
     end


### PR DESCRIPTION
One single widget pages, the "link to graph" tab has been changed to "link to dashboard".

I'm not sure how you guys want to handle all the pre-existing shortened urls that don't have a dashboard, so let me know. I was about to write a migration and associate them all to a new dashboard, but then the single widget page would have a bogus dashboard link.

requested in #120 
