### PR TITLE
Format page title

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  def page_title(title = nil)
+    if title
+      raise ArgumentError, 'title must be a string' unless title.is_a?(String)
+      content_for(:title, title)
+      title
+    else
+      [content_for(:title), 'Prometheus Dashboard'].compact.join(' | ')
+    end
+  end
 end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -1,4 +1,4 @@
-<h2>Dashboards</h2>
+<h2><%= page_title 'Dashboards' %></h2>
 
 <%= form_tag(new_dashboard_path, method: 'get') do %>
   <button type="submit" class="btn btn-primary">New Dashboard</button>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -4,7 +4,7 @@
   servers = <%= @servers.to_json.html_safe %>;
 </script>
 
-<h1 class="col-lg-12"><%= @dashboard.name %></h1>
+<h1 class="col-lg-12"><%= page_title @dashboard.name %></h1>
 
 <div id="dashboard" ng-controller="DashboardCtrl">
   <div id="global_controls">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" ng-app="Prometheus" ng-controller="ThemeCtrl" class="{{theme()}}">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><%= content_for?(:title) ? yield(:title) : "Prometheus Dashboard" %></title>
+    <title><%= page_title %></title>
     <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "Rails Bootstrap" %>">
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>

--- a/app/views/layouts/single_widget.html.erb
+++ b/app/views/layouts/single_widget.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" ng-app="Prometheus" ng-controller="ThemeCtrl" class="{{theme()}}">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><%= content_for?(:title) ? yield(:title) : "Prometheus Dashboard" %></title>
+    <title><%= page_title %></title>
     <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "Prometheus, yo." %>">
 
     <%= stylesheet_link_tag "application", :media => "all" %>

--- a/app/views/servers/index.html.erb
+++ b/app/views/servers/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Listing servers</h1>
+<h1><%= page_title 'Servers' %></h1>
 
 <%= form_tag(new_server_path, method: 'get') do %>
   <button type="submit" class="btn btn-primary">New Server</button>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe ApplicationHelper do
+  describe '#page_title' do
+    context 'given no input' do
+      it 'returns a default title' do
+        expect(helper.page_title).to be_a(String)
+      end
+
+      it 'includes a set content variable title' do
+        helper.content_for(:title, 'dashboards')
+
+        expect(helper.page_title).to match('dashboards')
+      end
+    end
+
+    context 'given a string' do
+      it 'returns the given value' do
+        expect(helper.page_title('title')).to eql('title')
+      end
+
+      it 'sets the title content variable' do
+        helper.page_title('page')
+
+        expect(helper.content_for(:title)).to eql('page')
+      end
+    end
+
+    context 'given any other input' do
+      it 'raises an ArgumentError' do
+        expect { helper.page_title([]) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change adds support to set custom page titles and adds meaningful
titles for dashboard and server main views.

```
ApplicationHelper
  #page_title
    given no input
      returns a default title
      includes a set content variable title
    given a string
      returns the given value
      sets the title content variable
    given any other input
      raises an ArgumentError
```
