### PR TITLE
[wip] Allow users to start from fullscreen

### DIFF
--- a/app/assets/javascripts/angular/app.js
+++ b/app/assets/javascripts/angular/app.js
@@ -14,4 +14,6 @@ angular.module("Prometheus",
   $rootScope.alert = function(thing) {
     alert(thing);
   };
+}]).config(["$locationProvider", function($locationProvider) {
+  $locationProvider.html5Mode(true);
 }]);

--- a/app/assets/javascripts/angular/controllers/dashboard_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/dashboard_ctrl.js
@@ -1,4 +1,4 @@
-angular.module("Prometheus.controllers").controller('DashboardCtrl',["$scope", "$window", "$http", "$timeout", "$document", "WidgetHeightCalculator", "UrlConfigEncoder", "SharedGraphBehavior", function($scope, $window, $http, $timeout, $document, WidgetHeightCalculator, UrlConfigEncoder, SharedGraphBehavior) {
+angular.module("Prometheus.controllers").controller('DashboardCtrl', ["$scope", "$window", "$http", "$timeout", "$document", "$location", "WidgetHeightCalculator", "UrlConfigEncoder", "SharedGraphBehavior", function($scope, $window, $http, $timeout, $document, $location, WidgetHeightCalculator, UrlConfigEncoder, SharedGraphBehavior) {
   $window.onresize = function() {
     $scope.$broadcast('redrawGraphs');
   }
@@ -15,7 +15,7 @@ angular.module("Prometheus.controllers").controller('DashboardCtrl',["$scope", "
     return angular.toJson(angular.copy(currentObj)) !== angular.toJson(originalObj);
   }
 
-  $scope.fullscreen = false;
+  $scope.fullscreen = $location.search().fullscreen;
   $scope.saving = false;
   $scope.aspectRatios = [
     {value: 0.75,    fraction: "4:3"},


### PR DESCRIPTION
Setting `fullscreen=true` in the query string automagically starts the dashboard in fullscreen mode.

@juliusv I'm not very familiar with how template variables are used. The good news is it seems to work, the bad news is that `fullscreen=true` gets wrapped up into the hash.

gahh this is totally busted, don't bother looking at it.
