### PR TITLE
(near) Zero-Fill the Series

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -176,6 +176,10 @@ angular.module("Prometheus.directives").directive('graphChart', ["$location", "W
           }
         });
 
+        // Insert (x, null) pair at any discontinuity in the data.
+        // Rickshaw.Series.zeroFill breaks logarithmic graphs.
+        Rickshaw.Series.fill(series, null);
+
         // If all series are removed from a certain axis but a scale has been
         // assigned to that axis, it will render with the wrong range.
         if (!a1series.length) {


### PR DESCRIPTION
Stacked graph types break when they have discontinuities. Before, this was handled by zero-filling the data, which was erroneously (although now seemingly fortuitously) removed. Zero Filling breaks logarithmic graphs, so we have to "near zero fill". Because we do the zero filling after the range for the axes has been calculated, it doesn't affect how data is displayed, and prevents the stack bugs. This also shouldn't affect any line or scatterplot charts, but test against some to let me know (I didn't find any errors).

fixes #140 
