### PR TITLE
Add hostname and hostnamef filters

### DIFF
--- a/app/assets/javascripts/angular/filters/filters.js
+++ b/app/assets/javascripts/angular/filters/filters.js
@@ -10,11 +10,19 @@ angular.module("Prometheus.filters").filter('toPercentile', function() {
   }
 });
 
-angular.module("Prometheus.filters").filter('hostname', function() {
+angular.module("Prometheus.filters").filter('hostnameFqdn', function() {
   return function(input) {
     var a = document.createElement("a");
     a.href = input;
     return a.host;
+  }
+});
+
+angular.module("Prometheus.filters").filter('hostname', function() {
+  return function(input) {
+    var a = document.createElement("a");
+    a.href = input;
+    return a.host.split(".", 1)[0];
   }
 });
 


### PR DESCRIPTION
In most cases, the unqualifed hostname is enough to have a unique
identifier. The full hostnames usually repeat some common suffix/port.
This change adds the semantics of the unix "hostname" and "hostname -f"
commands.

Examples:

```
url = "http://foo.bar.baz.example.org:5030/metrics"

{{ url | hostnamef }} // foo.bar.baz.example.org:5030
{{ url | hostname }}  // foo
```
