### PR TITLE
Remove global variable from regex interpolation

### DIFF
--- a/app/assets/javascripts/angular/services/variable_interpolator.js
+++ b/app/assets/javascripts/angular/services/variable_interpolator.js
@@ -43,8 +43,8 @@ angular.module("Prometheus.services").factory('VariableInterpolator', ["$rootSco
 
     // Replace the filtered variables.
     for (var i in pipeObj) {
-      // Need to escape the | in the piped statement.
-      escapedSeq = i.replace(/\|/g, "\\|")
+      // Need to escape any special matchers.
+      var escapedSeq = i.replace(/([.*+?^=!:$()|\[\]\/\\])/g, "\\$1");
       str = str.replace(new RegExp(escapedSeq, "g"), pipeObj[i]);
     }
 


### PR DESCRIPTION
Found a global variable in the regex filter, while realized that using special matchers was not longer working.

e.g.

`{{instance | regex:"^http":""}}` was not being properly escaped, so it wouldn't match `http` at the front of a string.
