### PR TITLE
Fix Rickshaw memory leaks.

### DIFF
--- a/app/assets/templates/graph_template.html.erb
+++ b/app/assets/templates/graph_template.html.erb
@@ -167,8 +167,10 @@
     </div>
 
     <div ng-click="showTab = null">
-      <div class="graph_chart" graph-chart graph-settings="graph" graph-data="data" aspect-ratio="aspectRatio" vars="vars">
-        <div class="legend"></div>
+      <div graph-chart graph-settings="graph" graph-data="data" aspect-ratio="aspectRatio" vars="vars">
+        <div class="graph_chart">
+          <div class="legend"></div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This fixes the majority of (if not all) Rickshaw memory leaks, which are
the ones we are most concerned with when a dashboard is displayed in
fullscreen TV mode and the graphs are continuously refreshing.

Details:
- This goes back to approach of always drawing the entire graph upon any
  change to it. This is saner, as we can always start out with a
  known-good, blank slate.
- To actually get to a blank slate, we need to attach the Rickshaw graph
  to an element one level deeper than before, which we can remove and
  recreate completely upon every redraw, so all attached event handlers
  are removed (mainly hover-detail).
- When loading a medium-sized dashboard and redrawing graphs 40x:
  - OLD: 31MB -> 130MB (99MB growth)
  - NEW: 31MB ->  33MB (2MB growth)

This fixes https://github.com/prometheus/promdash/issues/64
This fixes https://github.com/prometheus/promdash/issues/113
