### PR TITLE
Display hover detail labels as table.

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -260,13 +260,13 @@ angular.module("Prometheus.directives").directive('graphChart', ["$location", "W
       }
 
       function renderLabels(labels) {
-        var labelStrings = [];
+        var labelRows = [];
         for (label in labels) {
           if (label != "__name__") {
-            labelStrings.push("<strong>" + label + "</strong>: " + labels[label]);
+            labelRows.push("<tr><th>" + label + "</th><td>" + labels[label] + "</td></tr>");
           }
         }
-        return labels = "<div class=\"labels\">" + labelStrings.join("<br>") + "</div>";
+        return "<table class=\"labels_table\">" + labelRows.join("") + "</table>";
       }
 
       scope.$watch('graphSettings.stacked', redrawGraph);

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -177,8 +177,15 @@ $light-secondary-background: #f0f0f0;
     color: #a0a0a0;
   }
 
-  .labels {
+  .labels_table {
+    margin-top: 2px;
     font-size: 11px;
+    th, td {
+      padding: 0;
+    }
+    th {
+      padding-right: 7px;
+    }
   }
 }
 


### PR DESCRIPTION
![labels_table](https://cloud.githubusercontent.com/assets/538008/2846729/2c1a779a-d0a6-11e3-951a-3fe2638c13b3.png)

/cc @grobie (btw, the opacity looks wrong in the screenshot for some reason. Only the layout actually changed)
