### PR TITLE
Fix stacked axis ranges

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -178,10 +178,15 @@ angular.module("Prometheus.directives").directive('graphChart', ["$location", "W
           element: graphEl,
           renderer: 'multi',
           min: yMinForGraph,
-          max: scaleId ? yScales[scaleId](graphMax) : 1,
           interpolation: scope.graphSettings.interpolationMethod,
           series: series
         });
+
+        if (scaleId) {
+          rsGraph.max = yScales[scaleId](graphMax);
+        } else {
+          rsGraph.max = rsGraph.renderer.domain().y[1];
+        }
 
         var $legend = $el.find(".legend");
         var legend = createLegend(rsGraph, $legend[0]);


### PR DESCRIPTION
Stacked axis ranges are currently defaulting to 1, or 100% of their max value. Stacked graphs, by virtue of being stacked, will always exceed 1. Set the max to that value, the ratio of the highest value in the series.
