### PR TITLE
left align partially hidden widget options

### DIFF
--- a/app/assets/javascripts/angular/controllers/frame_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/frame_ctrl.js
@@ -1,4 +1,21 @@
-angular.module("Prometheus.controllers").controller('FrameCtrl', ["$scope", "$sce", "VariableInterpolator", "UrlHashEncoder", "InputHighlighter", "WidgetLinkHelper", "GraphiteTimeConverter", "ModalService", function($scope, $sce, VariableInterpolator, UrlHashEncoder, InputHighlighter, WidgetLinkHelper, GraphiteTimeConverter, ModalService) {
+angular.module("Prometheus.controllers").controller('FrameCtrl', ["$scope",
+                                                    "$sce", "$timeout",
+                                                    "VariableInterpolator",
+                                                    "UrlHashEncoder",
+                                                    "InputHighlighter",
+                                                    "WidgetLinkHelper",
+                                                    "GraphiteTimeConverter",
+                                                    "ModalService",
+                                                    "CheckWidgetMenuAlignment",
+                                                    function($scope, $sce,
+                                                             $timeout,
+                                                             VariableInterpolator,
+                                                             UrlHashEncoder,
+                                                             InputHighlighter,
+                                                             WidgetLinkHelper,
+                                                             GraphiteTimeConverter,
+                                                             ModalService,
+                                                             CheckWidgetMenuAlignment) {
   // Appended to frame source URL to trigger refresh.
   $scope.refreshCounter = 0;
 
@@ -39,6 +56,9 @@ angular.module("Prometheus.controllers").controller('FrameCtrl', ["$scope", "$sc
 
   $scope.toggleTab = function(tab) {
     $scope.showTab = $scope.showTab == tab ? null : tab;
+    if ($scope.showTab) {
+      $timeout(CheckWidgetMenuAlignment(tab), 0);
+    }
   };
 
   function buildFrameURL(url) {

--- a/app/assets/javascripts/angular/controllers/graph_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/graph_ctrl.js
@@ -1,4 +1,24 @@
-angular.module("Prometheus.controllers").controller('GraphCtrl', ["$scope", "$http", "$window", "VariableInterpolator", "UrlHashEncoder", "GraphRefresher", "ServersByIdObject", "WidgetLinkHelper", "ModalService", "YAxisUtilities", function($scope, $http, $window, VariableInterpolator, UrlHashEncoder, GraphRefresher, ServersByIdObject, WidgetLinkHelper, ModalService, YAxisUtilities) {
+angular.module("Prometheus.controllers").controller('GraphCtrl', ["$scope",
+                                                    "$http", "$window",
+                                                    "$timeout",
+                                                    "VariableInterpolator",
+                                                    "UrlHashEncoder",
+                                                    "GraphRefresher",
+                                                    "ServersByIdObject",
+                                                    "WidgetLinkHelper",
+                                                    "ModalService",
+                                                    "CheckWidgetMenuAlignment",
+                                                    "YAxisUtilities",
+                                                    function($scope, $http,
+                                                             $window, $timeout,
+                                                             VariableInterpolator,
+                                                             UrlHashEncoder,
+                                                             GraphRefresher,
+                                                             ServersByIdObject,
+                                                             WidgetLinkHelper,
+                                                             ModalService,
+                                                             CheckWidgetMenuAlignment,
+                                                             YAxisUtilities) {
   $scope.generateWidgetLink = function(event) {
     if ($scope.showTab !== 'staticlink') {
       return;
@@ -39,6 +59,9 @@ angular.module("Prometheus.controllers").controller('GraphCtrl', ["$scope", "$ht
 
   $scope.toggleTab = function(tab) {
     $scope.showTab = $scope.showTab == tab ? null : tab;
+    if ($scope.showTab) {
+      $timeout(CheckWidgetMenuAlignment(tab), 0);
+    }
   };
 
   $scope.addExpression = function() {

--- a/app/assets/javascripts/angular/directives/widget_time_options.js.erb
+++ b/app/assets/javascripts/angular/directives/widget_time_options.js.erb
@@ -6,6 +6,7 @@ angular.module("Prometheus.directives").directive('widgetTimeOptions', function(
       range: "=",
     },
     link: function(scope, element, attrs) {
+      element.addClass("graph_control_tabpane");
       scope.increaseRange = function() {
         scope.range = Prometheus.Graph.nextLongerRange(scope.range);
       };

--- a/app/assets/javascripts/angular/services/check_widget_menu_alignment.js
+++ b/app/assets/javascripts/angular/services/check_widget_menu_alignment.js
@@ -1,0 +1,17 @@
+angular.module("Prometheus.services").factory("CheckWidgetMenuAlignment", function() {
+  return function(tab) {
+    return function() {
+      // Check element position and add the right aligning class if needed.
+      var $el = $("[ng-show=\"showTab == '" + tab + "'\"]");
+      var rect = $el[0].getBoundingClientRect();
+
+      if (rect.left < 0) {
+        $el.addClass("alignLeft");
+        $el.closest(".graph_control_tabbar").addClass("alignLeft");
+      } else {
+        $el.removeClass("alignLeft");
+        $el.closest(".graph_control_tabbar").removeClass("alignLeft");
+      }
+    }
+  }
+});

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -653,3 +653,8 @@ hr {
 .panel-default > .panel-heading {
   background-color: $light-secondary-background;
 }
+// Over-ride bootstrap.
+.alignLeft {
+  position: absolute;
+  left: 0;
+}

--- a/app/assets/templates/frame_template.html
+++ b/app/assets/templates/frame_template.html
@@ -24,7 +24,10 @@
       </div>
 
       <!-- 2) Time Options -->
-      <widget-time-options ng-show="showTab == 'timerange'" range="frame.range" end-time="frame.endTime"></widget-time-options>
+      <widget-time-options
+        ng-show="showTab == 'timerange'"
+        range="frame.range"
+        end-time="frame.endTime"></widget-time-options>
 
       <!-- 3) Frame Settings -->
       <div class="graph_control_tabpane panel panel-default" ng-show="showTab == 'frame_settings'">

--- a/app/assets/templates/widget_time_options_template.html
+++ b/app/assets/templates/widget_time_options_template.html
@@ -1,4 +1,4 @@
-<div class="graph_control_tabpane panel panel-default">
+<div class="panel panel-default">
   <div class="panel-heading">Time Options</div>
   <div class="panel-body">
     <div class="col-lg-4">


### PR DESCRIPTION
Upon opening a widget menu option, if that option is off the left-hand side of the screen it will now be left aligned (and visible).

This check only occurs when opening a widget option menu. If you were to open a menu and then resize the window, the menu's position will not be updated if the newly resized window forces the menu outside of the screen. @juliusv is this ok, or would you like to have an open menu checked when someone resizes the window?
