### PR TITLE
Add &until=now to frame url query strings missing until parameter.

### DIFF
--- a/app/assets/javascripts/angular/controllers/frame_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/frame_ctrl.js
@@ -66,6 +66,9 @@ angular.module("Prometheus.controllers").controller('FrameCtrl', ["$scope",
     parser.href = url;
     var queryStringComponents = parser.search.substring(1).split('&');
     if ($scope.frame.graphite) {
+      if (url.indexOf("until") === -1) {
+        queryStringComponents.push("until=now");
+      }
       queryStringComponents = queryStringComponents.map(function(e) {
         switch (0) {
         case e.indexOf('height='):


### PR DESCRIPTION
Missing this parameter broke setting frame end time via query string, e.g. http://promdash/web-status#?range=30m&until=2014-09-24T17:53:52.223Z

addresses #192 
