### PR TITLE
Disable refreshing graphs if 'until' query parameter present.

### DIFF
--- a/app/assets/javascripts/angular/resources/shared_graph_behavior.js
+++ b/app/assets/javascripts/angular/resources/shared_graph_behavior.js
@@ -96,7 +96,7 @@ angular.module("Prometheus.services").factory("SharedGraphBehavior", ["$http", "
       if ($scope.refreshTimer) {
         $timeout.cancel($scope.refreshTimer);
       }
-      if ($scope.globalConfig.refresh) {
+      if ($scope.globalConfig.refresh && !urlVars.until) {
         setupRefreshTimer(Prometheus.Graph.parseDuration($scope.globalConfig.refresh));
       }
     });


### PR DESCRIPTION
requested in #183
