### PR TITLE
Make PromDash deal with empty metric names.

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -255,7 +255,7 @@ angular.module("Prometheus.directives").directive('graphChart', ["$location", "W
           formatter: function(series, x, y) {
             var date = '<span class="date">' + new Date(x * 1000).toUTCString() + '</span>';
             var swatch = '<span class="detail_swatch" style="background-color: ' + series.color + '"></span>';
-            var content = swatch + series.labels["__name__"] + ": <strong>" + y + '</strong>';
+            var content = swatch + (series.labels["__name__"] || 'value') + ": <strong>" + y + '</strong>';
             return date + '<br>' + content + '<br>' + renderLabels(series.labels);
           },
           onRender: function() {

--- a/app/assets/javascripts/angular/directives/pie_chart.js
+++ b/app/assets/javascripts/angular/directives/pie_chart.js
@@ -39,7 +39,7 @@ angular.module("Prometheus.directives").directive('pieChart', ["$location", "Wid
                 return "=\"" + $2 + "\"";
               });
             }).join(",");
-            e.ts = e.Metric["__name__"] + "{" + ts + "}";
+            e.ts = (e.Metric["__name__"] || '') + "{" + ts + "}";
           }
         });
 
@@ -52,7 +52,7 @@ angular.module("Prometheus.directives").directive('pieChart', ["$location", "Wid
         pies.radius = (graphHeight / 2) - 10
         pies.getTooltipText = function(e) {
           var data = tooltip[e.aggField[0]];
-          var tt = [data["__name__"] + ": " + e.pValue];
+          var tt = [(data["__name__"] || 'value') + ": " + e.pValue];
           return tt.concat(joinProperties(data, ": "));
         };
 

--- a/app/assets/javascripts/angular/services/rickshaw_data_transformer.js
+++ b/app/assets/javascripts/angular/services/rickshaw_data_transformer.js
@@ -8,7 +8,7 @@ angular.module("Prometheus.services").factory('RickshawDataTransformer', [functi
   }
 
   function metricToTsName(labels) {
-    var tsName = labels["__name__"] + "{";
+    var tsName = (labels["__name__"] || '') + "{";
     var labelStrings = [];
     for (label in labels) {
       if (label != "__name__") {


### PR DESCRIPTION
The Prometheus server is being changed to drop metric names after
transformations like sum(), avg(), etc., since the result of these
transformations is not the original metric anymore. Thus, the metric
name of timeseries may be empty now. PromDash needs to deal with this.
