### PR TITLE
Expand graphite URLs.

### DIFF
--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -709,3 +709,13 @@ hr {
 .form-inline .form-group {
   margin-bottom: 5px;
 }
+
+.frame_query_string_key {
+  min-width: 100px;
+  padding: 8px 12px;
+  text-align: right;
+}
+
+.form-inline .form-control.frame_query_string_value {
+  width: 338px;
+}

--- a/app/assets/templates/frame_template.html
+++ b/app/assets/templates/frame_template.html
@@ -18,8 +18,23 @@
       <div class="graph_control_tabpane panel panel-default" ng-show="showTab == 'frame_source'">
         <div class="panel-heading">Frame Source</div>
         <div class="panel-body">
-          <input type="text" class="form-control" ng-model="urlInput" ng-changed="updateURL()" placeholder="Enter URL" required>
-          <input type="text" class="form-control" ng-model="frame.title" placeholder="Enter Title" required>
+          <form class="form-inline">
+            <div class="form-group col-xs-12">
+              <input type="text" class="form-control" ng-changed="generateFrameComponents()" ng-model="frame.url" placeholder="Enter URL" required>
+            </div>
+          </form>
+          <div class="form-group col-xs-12">
+            <input type="text" class="form-control" ng-model="frame.title" placeholder="Enter Title" required>
+          </div>
+          <div class="col-xs-12"><b>Query String Key/Value Pairs</b></div>
+          <form class="form-inline">
+            <div class="form-group col-xs-12" ng-repeat="qs in frameComponents" ng-if="!skipComponent(qs.key)">
+              <div class="input-group">
+                <input class="input-group-addon frame_query_string_key" ng-model="qs.key">
+                <input class="form-control frame_query_string_value" ng-model="qs.value" placeholder="Enter value for {{qs.key}}" ng-disabled="qs.value === undefined">
+              </div>
+            </div>
+          </form>
         </div>
       </div>
 


### PR DESCRIPTION
Graphite URLs are expanded into component pieces for easier manipulation.

Updating the frame.url requires the input to be blurred in order for the components to be updated (live updates cause weird things to happen to the components when new query strings are partially entered).

addresses #219
