### PR TITLE
Show "null" values as gaps instead of zero.

### DIFF
--- a/app/assets/javascripts/angular/services/y_axis_utilities.js
+++ b/app/assets/javascripts/angular/services/y_axis_utilities.js
@@ -1,14 +1,25 @@
 angular.module("Prometheus.services").factory('YAxisUtilities', [function() {
   var logScale, linearScale;
+  // Extends a D3 scale to ignore "null" values.
+  function extendScale(scale) {
+    var extendedScale = function(y) {
+      if (y === null) {
+        return null;
+      }
+      return scale(y);
+    }
+    extendedScale.__proto__ = scale;
+    return extendedScale;
+  }
   return {
     setLogScale: function(min, max) {
-      return logScale = d3.scale.log().domain([min, max]);
+      return logScale = extendScale(d3.scale.log().domain([min, max]));
     },
     setLinearScale: function(min, max) {
       if (!logScale) {
         throw("Must set logScale first!");
       }
-      return linearScale = d3.scale.linear().domain([min, max]).range(logScale.range());
+      return linearScale = extendScale(d3.scale.linear().domain([min, max]).range(logScale.range()));
     },
     getScale: function(scale) {
       return scale === "log" ? logScale : linearScale;


### PR DESCRIPTION
Rickshaw uses D3 scales to scale data on the Y-axis. When these
predefined linear and log scales encounter a "null" value in the source
data, they scale the resulting data point to a Y value of 0. This change
wraps the D3 scales in such a way that "null" values are intercepted and
left unchanged, while all other values are passed through to the D3
scale transparently. Since D3 scales are both an object and a function
at the same time (yeah, JavaScript, you crazy, crazy language), this
needs some protoypical inheritance trickery to override the function
part of the scale.
