### PR TITLE
Add deterministic colors for http status codes.

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -114,6 +114,15 @@ angular.module("Prometheus.directives").directive('graphChart', ["$location", "W
 
           s.color = palette.color();
 
+          var statusCode;
+          if (scope.graphSettings.palette == "httpStatus" && s.name.match(/http/)) {
+            var m = s.name.match(/statusClass="(\d.{2})"/);
+            if (m[1]) {
+              statusCode = parseInt(m[1].replace(/x/g, "0"), 0);
+              s.color = palette.color(statusCode);
+            }
+          }
+
           var bound = axesBounds[matchingAxis.id];
           var min = bound.min > 0 ? 0 : bound.min;
 

--- a/app/assets/javascripts/angular/services/palettes.js
+++ b/app/assets/javascripts/angular/services/palettes.js
@@ -1,6 +1,7 @@
 angular.module("Prometheus.services").factory('Palettes', function() {
   return [
     'spectrum2000',
+    'httpStatus',
     'munin',
     'spectrum14',
     'spectrum2001',


### PR DESCRIPTION
fixes the inconsistent http status colors across different dashboards.

2xx status codes are a shade of blue. since we have rickshaw vendored we could easily change it to, say, a green color (which I think would be more expected).

@juliusv 
