### PR TITLE
Allow specifying servers by URL in dashboard_json.

### DIFF
--- a/lib/server_transformer.rb
+++ b/lib/server_transformer.rb
@@ -1,0 +1,34 @@
+# The exception to be raised when a server specified by URL in the
+# dashboard_json cannot be found in the database.
+class ServerNotFoundError < Exception
+end
+
+module ServerTransformer
+  # Iterate through all incoming widgets and transform any servers specified by
+  # their URL into servers specified by their ID.
+  def self.transform(dashboard_json)
+    dashboard_json['widgets'].each do |w|
+      case w['type']
+      when 'graph'
+        w['expressions'].each do |e|
+          transform_server(e)
+        end
+      when 'pie'
+        transform_server(w['expression'])
+      end
+    end
+  end
+
+  private
+
+  def self.transform_server(obj)
+    if url = obj['serverURL']
+      server = Server.find_by_url(url)
+      unless server
+        raise ServerNotFoundError, "No server with URL #{obj['serverURL']}"
+      end
+      obj['serverID'] = server.id
+      obj.delete('serverURL')
+    end
+  end
+end

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -44,6 +44,28 @@ describe DashboardsController do
         expect(response.status).to eq 422
       }.not_to change{ Dashboard.count }
     end
+
+    it "creates a dashboard given an existing server URL" do
+      Server.create(name: 'test-server', url: 'http://test-server:9090/')
+      dashboard_json = File.read('./spec/support/sample_json/server_by_url.json')
+      dashboard_obj = JSON.parse(dashboard_json)
+      expect {
+        post :create, format: 'json', dashboard: { name: "example dash", dashboard_json: dashboard_obj }
+        expect(response.status).to eq 201
+      }.to change{ Dashboard.count }.by(1)
+      expect(Dashboard.last.dashboard_json).not_to match("serverURL")
+      expect(Dashboard.last.dashboard_json).to match("serverID")
+    end
+
+    it "fails to create a dashboard containing a non-existent server URL" do
+      dashboard_json = File.read('./spec/support/sample_json/server_by_url.json')
+      dashboard_obj = JSON.parse(dashboard_json)
+      expect {
+        post :create, format: 'json', dashboard: { name: "example dash", dashboard_json: dashboard_obj }
+        expect(response.status).to eq 422
+        expect(response.body).to match("No server with URL http://test-server:9090/")
+      }.not_to change{ Dashboard.count }
+    end
   end
 
   it "#show" do

--- a/spec/support/sample_json/server_by_url.json
+++ b/spec/support/sample_json/server_by_url.json
@@ -1,0 +1,30 @@
+{"globalConfig":
+  {"numColumns":2,
+   "aspectRatio":0.75,
+   "theme":"dark_theme",
+   "endTime":null,
+   "vars":{}},
+   "widgets":[
+     {"title":"Title",
+      "range":"1h",
+      "endTime":null,
+      "expressions":[
+        {"serverURL":"http://test-server:9090/",
+         "id":0,
+         "legendID":1,
+         "axisID":1,
+         "expression":"prometheus_targetpool_duration_ms"}
+      ],
+      "type":"graph",
+      "showLegend":"sometimes",
+      "interpolationMethod":"cardinal",
+      "axes":[
+        {"orientation":"left",
+         "renderer":"line",
+         "scale":"linear",
+         "format":"kmbt",
+         "id":1}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This allows users who upload their dashboard_json via HTTP put to
specify a "serverURL" property for expressions in place of specifying
the server via its ID in the "serverID" property (in case a URL is
specified, any supplied ID is ignored). The URL has to exactly match the
URL of an existing server in PromDash's database (instead of creating a
new server ad-hoc for new URLs). We want to err on the side of caution
here so that people notice immediately if they don't happen to specify
the right server.

Since this feature is kind of dirty, I wanted to keep any code for it
out of the model and the JSON schema, and immediately transform any
incoming JSON into the (existing) expected format in the controller.
