### PR TITLE
Add watch on the 'until' query parameter that disables/enables the

### DIFF
--- a/app/assets/javascripts/angular/resources/shared_graph_behavior.js
+++ b/app/assets/javascripts/angular/resources/shared_graph_behavior.js
@@ -1,4 +1,4 @@
-angular.module("Prometheus.services").factory("SharedGraphBehavior", ["$http", "$timeout", "URLConfigDecoder", "URLVariablesDecoder", "ThemeManager", function($http, $timeout, URLConfigDecoder, URLVariablesDecoder, ThemeManager) {
+angular.module("Prometheus.services").factory("SharedGraphBehavior", ["$http", "$timeout", "$location", "URLConfigDecoder", "URLVariablesDecoder", "ThemeManager", function($http, $timeout, $location, URLConfigDecoder, URLVariablesDecoder, ThemeManager) {
   function commonSetup($scope) {
     $scope.globalConfig = dashboardData.globalConfig || {
       numColumns: 2,
@@ -113,9 +113,20 @@ angular.module("Prometheus.services").factory("SharedGraphBehavior", ["$http", "
       if ($scope.refreshTimer) {
         $timeout.cancel($scope.refreshTimer);
       }
-      if ($scope.globalConfig.refresh && !urlVars.until) {
+      if ($scope.globalConfig.refresh) {
         setupRefreshTimer(Prometheus.Graph.parseDuration($scope.globalConfig.refresh));
       }
+    });
+
+    $scope.$watch(function() {
+      return $location.search().until;
+    }, function(until) {
+      if (until) {
+        $scope.globalConfig.refresh = '';
+        $(".js-refresh").addClass("disabled");
+        return
+      }
+      $(".js-refresh").removeClass("disabled");
     });
   }
 

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -34,7 +34,7 @@
 
     <div class="global_grouping">
       <button type="button" class="btn btn-default" ng-click="refreshDashboard()" title="Refresh dashboard"><i class="icon-cycle"></i></button>
-      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+      <button type="button" class="btn btn-default dropdown-toggle js-refresh" data-toggle="dropdown">
         <span ng-if="globalConfig.refresh">every {{globalConfig.refresh}}</span>
         <span ng-if="!globalConfig.refresh">never</span>
         <span class="caret"></span>


### PR DESCRIPTION
globalRefresh dropdown button.

requested in #260