### PR TITLE
Add `overflow: auto;` to expression form to force line break.

### DIFF
--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -609,6 +609,10 @@ hr {
   width: 75%;
 }
 
+.expression_form {
+  overflow: auto;
+}
+
 .expression_select {
   padding: 0;
 }

--- a/app/assets/templates/expression_template.html
+++ b/app/assets/templates/expression_template.html
@@ -1,5 +1,5 @@
 <div><b>Expression {{index + 1}}</b></div>
-<form class="form-inline">
+<form class="form-inline expression_form">
   <div class="form-group col-xs-4 pad-right expression_select" ng-class="{'col-xs-12': type !== 'graph' }">
     <select class="form-control"
       ng-model="expr.serverID"


### PR DESCRIPTION
@juliusv 

## before
![image](https://cloud.githubusercontent.com/assets/1398104/5721968/147033c0-9b38-11e4-9cc0-bf5619dd60e7.png)

## after
![image](https://cloud.githubusercontent.com/assets/1398104/5721963/fb26e76a-9b37-11e4-82b5-076f7d637d38.png)
