### PR TITLE
Remove encoding/decoding of user-facing frame urls.

### DIFF
--- a/app/assets/javascripts/angular/controllers/frame_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/frame_ctrl.js
@@ -61,10 +61,10 @@ angular.module("Prometheus.controllers").controller('FrameCtrl', ["$scope",
     var queryStringComponents = parser.search.substring(1).split("&");
     // [{foo: bar}, {baz: quux}]
     $scope.frameComponents = queryStringComponents.map(function(kv) {
-      var kvArr = kv.split("=");
+      var kvArr = unescape(kv).split(/=(.+)/);
       return {
         key: kvArr[0],
-        value: kvArr[1] === undefined ? undefined : decodeURIComponent(kvArr[1]),
+        value: kvArr[1],
       };
     });
   };
@@ -79,15 +79,21 @@ angular.module("Prometheus.controllers").controller('FrameCtrl', ["$scope",
     if (angular.equals(newValue, oldValue)) {
       return;
     }
+    initFrameURL();
+  }, true);
+
+  function initFrameURL() {
     var parser = document.createElement("a");
     parser.href = $scope.frame.url;
     parser.search = "?" + $scope.frameComponents.map(function(o) {
       if (o.value !== undefined) {
-        return o.key + "=" + encodeURIComponent(o.value);
+        return o.key + "=" + o.value;
       } else {
         return o.key;
       }
     }).join("&");
-    $scope.frame.url = parser.href;
-  }, true);
+    $scope.frame.escapedURL = VariableInterpolator(parser.href, $scope.vars);
+    $scope.frame.url = unescape(parser.href);
+  }
+  initFrameURL();
 }]);

--- a/app/assets/javascripts/angular/directives/frame.js.erb
+++ b/app/assets/javascripts/angular/directives/frame.js.erb
@@ -17,7 +17,12 @@ angular.module("Prometheus.directives").directive('inlineFrame', ["$sce", "Varia
         return WidgetHeightCalculator(element.find(".js_widget_wrapper")[0], scope.aspectRatio);
       }
 
-      var a = ['frame.url', 'frame.range', 'frame.endTime', 'refreshCounter'];
+      scope.refreshFrame = function() {
+        var frame = element.find('.frame_container');
+        frame.html(frame.html());
+      };
+
+      var a = ['frame.url', 'frame.range', 'frame.endTime', 'refreshCounter', 'frame.graphite'];
       a.forEach(function(w) {
         scope.$watch(w, regenFrame);
       });
@@ -33,7 +38,11 @@ angular.module("Prometheus.directives").directive('inlineFrame', ["$sce", "Varia
       // history state added by modifying an iframe's src.
       // http://khaidoan.wikidot.com/iframe-and-browser-history
       function regenFrame() {
-        var url = VariableInterpolator(scope.frame.url, scope.vars);
+        if (!scope.frame.escapedURL) {
+          return;
+        }
+        var url = scope.frame.escapedURL.slice();
+        delete scope.frame.escapedURL;
         var trustedURL = $sce.trustAsResourceUrl(buildFrameURL(url));
         var frame = element.find('.frame_container');
         frame.height(frameHeight());

--- a/spec/javascripts/angular/controllers/frame_ctrl_spec.js
+++ b/spec/javascripts/angular/controllers/frame_ctrl_spec.js
@@ -1,0 +1,50 @@
+describe('FrameCtrl', function() {
+  var $controller;
+  var $scope;
+  beforeEach(inject(function(_$controller_, _VariableInterpolator_, $rootScope){
+    $controller = _$controller_;
+    $scope = $rootScope.$new(true);
+    $scope.frame = {};
+  }));
+
+  describe('frame.url', function() {
+    var url = 'http://graphite/render/?target=alias(stats_counts.statsd.{{xxx}}, "{{yyy}}: derp")';
+    beforeEach(function() {
+      $scope.vars = {xxx: 'packets_received', yyy: 'alias name'};
+      $scope.frame.url = url;
+      $controller('FrameCtrl', { $scope: $scope });
+      $scope.$apply();
+    });
+
+    it('doesnt escape or interpolate the displayed frame url', function() {
+      expect($scope.frame.url).toEqual(url);
+    });
+
+    it('escapes and interpolates the iframe src url', function() {
+      expect($scope.frame.escapedURL).toEqual('http://graphite/render/?target=alias(stats_counts.statsd.packets_received,%20%22alias name:%20derp%22)');
+    });
+  });
+
+  describe('generating frame components', function() {
+    it('only reads the search part of the url', function() {
+      $scope.frame.url = 'http://graphite/render/?target=alias(stats_counts.statsd.xxx, "doot")#&target=derp&foo=bar&baz=qux';
+      var controller = $controller('FrameCtrl', { $scope: $scope });
+      $scope.generateFrameComponents();
+      expect($scope.frameComponents).toEqual([
+        {key: 'target', value: 'alias(stats_counts.statsd.xxx, "doot")'}
+      ]);
+    });
+
+    it('splits the search', function() {
+      $scope.frame.url = 'http://graphite/render/?target=alias(stats_counts.statsd.xxx, "de==rp")&target=derp&foo=bar&baz=qux';
+      var controller = $controller('FrameCtrl', { $scope: $scope });
+      $scope.generateFrameComponents();
+      expect($scope.frameComponents).toEqual([
+        {key: 'target', value: 'alias(stats_counts.statsd.xxx, "de==rp")'},
+        {key: 'target', value: 'derp'},
+        {key: 'foo', value: 'bar'},
+        {key: 'baz', value: 'qux'}
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
I'm reasonably sure these `encode`/`decode` function calls were added for a reason in the original pull request, but I can't remember why now, and I can't find a comment about them. Do either of you remember what these were for? The frame construction code has since [changed](https://github.com/prometheus/promdash/commit/23897351e2420699a6ddf90538fcef70a343661b), and looking at dashboards with graphite widgets I'm not seeing any breakage, so maybe they aren't needed.

fixes #280 

@juliusv @grobie 