### PR TITLE
offer dashboard perma-link instead of base64 encoding after hash

### DIFF
--- a/app/assets/javascripts/angular/resources/shared_graph_behavior.js
+++ b/app/assets/javascripts/angular/resources/shared_graph_behavior.js
@@ -13,16 +13,6 @@ angular.module("Prometheus.services").factory("SharedGraphBehavior", ["$http", "
     };
     $scope.themeChange();
 
-    // If settings were passed in via the URL hash, merge them into globalConfig.
-    var urlConfig = URLConfigDecoder();
-    if (urlConfig.globalConfig) {
-      for (var o in urlConfig.globalConfig) {
-        $scope.globalConfig[o] = urlConfig.globalConfig[o];
-      }
-    }
-    if (urlConfig.widgets) {
-      $scope.widgets = urlConfig.widgets;
-    }
     // If we have manual variable overrides in the hashbang search part of the
     // URL (http://docs.angularjs.org/img/guide/hashbang_vs_regular_url.jpg),
     // merge them into the globalConfig's template vars.

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -664,13 +664,13 @@ hr {
 }
 
 @-moz-keyframes spin {
-  100% { -moz-transform: rotate(-360deg); }
+  100% { -moz-transform: rotate(360deg); }
 }
 @-webkit-keyframes spin {
-  100% { -webkit-transform: rotate(-360deg); }
+  100% { -webkit-transform: rotate(360deg); }
 }
 @keyframes spin {
-  100% { -webkit-transform: rotate(-360deg); transform:rotate(-360deg); }
+  100% { -webkit-transform: rotate(360deg); transform:rotate(360deg); }
 }
 
 // Over-ride bootstrap

--- a/app/assets/templates/frame_template.html
+++ b/app/assets/templates/frame_template.html
@@ -3,7 +3,7 @@
     <div class="widget_title panel-heading" ng-mouseenter="showControls = true" ng-mouseleave="showControls = false">
       {{getTitle()}}
       <div class="btn-group pull-right graph_config_menu" ng-show="showControls || showTab">
-        <div class="btn btn-primary btn-sm" ng-click="refreshFrame()" tooltip-append-to-body="true" tooltip="Refresh"><i ng-class="{spin:requestsInFlight}" class="icon-cycle"></i></div>
+        <div class="btn btn-primary btn-sm" ng-click="refreshFrame()" tooltip-append-to-body="true" tooltip="Refresh"><i ng-class="{spin:requestsInFlight}" class="glyphicon glyphicon-refresh"></i></div>
         <div class="btn btn-primary btn-sm" ng-click="toggleTab($event, 'frame_source')" tooltip-append-to-body="true" tooltip="Frame Source"><i class="icon-add-to-list"></i></div>
         <div class="btn btn-primary btn-sm" ng-show="frame.graphite" ng-click="toggleTab($event, 'timerange')" tooltip-append-to-body="true" tooltip="Time options"><i class="icon-clock"></i></div>
         <div class="btn btn-primary btn-sm" ng-click="toggleTab($event, 'frame_settings')" tooltip-append-to-body="true" tooltip="Frame Settings"><i class="icon-cog"></i></div>

--- a/app/assets/templates/graph_template.html.erb
+++ b/app/assets/templates/graph_template.html.erb
@@ -6,7 +6,7 @@
       {{title()}}
 
       <div class="btn-group pull-right graph_config_menu">
-        <div ng-show="showControls || showTab || requestsInFlight" class="btn btn-primary btn-sm" ng-click="refreshGraph()" tooltip-append-to-body="true" tooltip="Refresh"><i ng-class="{spin:requestsInFlight}" class="icon-cycle"></i></div>
+        <div ng-show="showControls || showTab || requestsInFlight" class="btn btn-primary btn-sm" ng-click="refreshGraph()" tooltip-append-to-body="true" tooltip="Refresh"><i ng-class="{spin:requestsInFlight}" class="glyphicon glyphicon-refresh"></i></div>
         <div ng-show="showControls || showTab" class="btn btn-primary btn-sm" ng-click="toggleTab($event, 'datasources')" tooltip-append-to-body="true" tooltip="Datasources"><i class="icon-add-to-list"></i></div>
         <div ng-show="showControls || showTab" class="btn btn-primary btn-sm" ng-click="toggleTab($event, 'timerange')" tooltip-append-to-body="true" tooltip="Time options"><i class="icon-clock"></i></div>
         <div ng-show="showControls || showTab" class="btn btn-primary btn-sm" ng-click="toggleTab($event, 'graph')" tooltip-append-to-body="true" tooltip="Graph and axis settings"><i class="icon-line-graph"></i></div>

--- a/app/assets/templates/pie_template.html.erb
+++ b/app/assets/templates/pie_template.html.erb
@@ -6,7 +6,7 @@
       {{title()}}
 
       <div class="btn-group pull-right graph_config_menu">
-        <div ng-show="showControls || showTab || requestsInFlight" class="btn btn-primary btn-sm" ng-click="refreshGraph()" tooltip-append-to-body="true" tooltip="Refresh"><i ng-class="{spin:requestInFlight}" class="icon-cycle"></i></div>
+        <div ng-show="showControls || showTab || requestsInFlight" class="btn btn-primary btn-sm" ng-click="refreshGraph()" tooltip-append-to-body="true" tooltip="Refresh"><i ng-class="{spin:requestInFlight}" class="glyphicon glyphicon-refresh"></i></div>
         <div ng-show="showControls || showTab" class="btn btn-primary btn-sm" ng-click="toggleTab($event, 'datasources')" tooltip-append-to-body="true" tooltip="Datasources"><i class="icon-add-to-list"></i></div>
         <div ng-show="showControls || showTab" class="btn btn-primary btn-sm" ng-click="toggleTab($event, 'graph')" tooltip-append-to-body="true" tooltip="Chart settings"><i class="icon-pie-chart"></i></div>
         <div ng-show="showControls || showTab" class="btn btn-primary btn-sm" ng-click="toggleTab($event, 'palette')" tooltip-append-to-body="true" tooltip="Palette"><i class="icon-palette"></i></div>

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -44,6 +44,18 @@ class DashboardsController < ApplicationController
     render json: res.read
   end
 
+  def permalink
+    @dashboard = Dashboard.new_permalink(dashboard_params)
+    if @dashboard.save
+      payload = {
+        url: "/permalink/" + SlugMaker.slug("#{@dashboard.id} #{@dashboard.slug}")
+      }
+      render json: payload, status: :created
+    else
+      render json: @dashboard.errors, status: :unprocessable_entity
+    end
+  end
+
   # POST /dashboards
   # POST /dashboards.json
   def create

--- a/app/controllers/directories_controller.rb
+++ b/app/controllers/directories_controller.rb
@@ -8,7 +8,7 @@ class DirectoriesController < ApplicationController
       format.html { render 'index' }
       format.json do
         @directories = @directories.select {|d| d.dashboards.present? }
-        if Dashboard.unassigned.present?
+        if Dashboard.where(permalink: false).unassigned.present?
           @directories << Dashboard.new(name: 'Unassigned dashboards')
         end
         render json: @directories
@@ -83,7 +83,7 @@ class DirectoriesController < ApplicationController
   end
 
   def set_unassigned_dashboards
-    @unassigned_dashboards = Dashboard.unassigned.alphabetical
+    @unassigned_dashboards = Dashboard.where(permalink: false).unassigned.alphabetical
   end
 
   def directory_params

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -36,6 +36,13 @@ class Dashboard < ActiveRecord::Base
     dashboard
   end
 
+  def self.new_permalink(params)
+    params[:name] = "#{params[:name]} #{Time.now.utc.to_s}"
+    d = new_with_slug(params)
+    d.permalink = true
+    d
+  end
+
   def make_clone
     clone = dup
     clone.name = "#{name} clone"

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -65,7 +65,32 @@
         <button class="btn btn-default" ng-click="enableFullscreen()" title="Fullscreen mode">
           <span class="glyphicon glyphicon-fullscreen"></span>
         </button>
+        <% unless @dashboard.permalink %>
+          <button class="btn btn-default" ng-click="generatePermalink()"
+            tooltip-append-to-body="true" tooltip="Create permalink to current dashboard state">
+            <span ng-show="!generatingPermalink" class="glyphicon glyphicon-link"></span>
+            <span ng-show="generatingPermalink" class="glyphicon glyphicon-refresh spin"></span>
+          </button>
+        <% end %>
       </div>
+      <% unless @dashboard.permalink %>
+        <div class="dashboard_settings panel panel-default" ng-show="showPermalink">
+          <div class="panel-heading">Dashboard Permalink</div>
+          <div class="panel-body">
+            <div class="input-group">
+              <input type="text" class="form-control" ng-model="permalink">
+              <span class="input-group-btn">
+                <a class="btn btn-default" href="{{permalink}}"
+                  tooltip-append-to-body="true"
+                  tooltip="Open dashboard permalink in new tab" target="_blank"
+                  ng-click="showPermalink = false">
+                  <span class="glyphicon glyphicon-new-window"></span>
+                </a>
+              </span>
+            </div>
+          </div>
+        </div>
+      <% end %>
       <div class="dashboard_settings panel panel-default" ng-show="showDashboardSettings">
         <div class="panel-heading">Dashboard Settings</div>
         <div class="panel-body">
@@ -117,20 +142,17 @@
               <input type="checkbox" ng-model="globalConfig.showVars"> Show template variables
             </label>
           </div>
-          <div class="checkbox">
-            <label>
-              <input type="checkbox" ng-model="globalConfig.encodeEntireURL"> Encode entire dashboard in URL
-            </label>
-          </div>
         </div>
       </div>
     </div>
-    <div class="global_grouping">
-      <button class="btn btn-default" ng-click="saveDashboard()" ng-disabled="saving">
-        <span ng-show="saving">Saving...</span>
-        <span ng-show="!saving">Save Changes</span>
-      </button>
-    </div>
+    <% unless @dashboard.permalink %>
+      <div class="global_grouping">
+        <button class="btn btn-default" ng-click="saveDashboard()" ng-disabled="saving">
+          <span ng-show="saving">Saving...</span>
+          <span ng-show="!saving">Save Changes</span>
+        </button>
+      </div>
+    <% end %>
     <span class="clearfix"></span>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ PrometheusDashboard::Application.routes.draw do
   get '/dashboards/:id/widgets', to: 'dashboards#widgets'
   get '/w/:slug', to: 'single_widget#show', as: 'single_widget'
   post '/w', to: 'single_widget#create'
+  get '/permalink/:id', to: 'dashboards#show'
+  post '/permalink', to: 'dashboards#permalink'
   get '/embed/:slug', to: 'embed#show'
   get '/:slug', to: 'dashboards#show', as: 'dashboard_slug'
   match '/:slug', to: 'dashboards#update', as: 'dashboard_slug_put', via: [:put, :patch]

--- a/db/migrate/20150126150102_add_permalink_attr_to_dashboards.rb
+++ b/db/migrate/20150126150102_add_permalink_attr_to_dashboards.rb
@@ -1,0 +1,5 @@
+class AddPermalinkAttrToDashboards < ActiveRecord::Migration
+  def change
+    add_column :dashboards, :permalink, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141107013708) do
+ActiveRecord::Schema.define(version: 20150126150102) do
 
   create_table "dashboards", force: true do |t|
     t.string   "name"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20141107013708) do
     t.datetime "updated_at"
     t.string   "slug"
     t.integer  "directory_id"
+    t.boolean  "permalink",      default: false
   end
 
   add_index "dashboards", ["directory_id"], name: "index_dashboards_on_directory_id", using: :btree

--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -23,6 +23,14 @@ describe DashboardsController do
       expect(response).to redirect_to(dashboard_slug_path(d.slug))
     end
 
+    it "creates a new permalink dashboard" do
+      d = Dashboard.new_with_slug(name: "static dash")
+      expect {
+        post :permalink, dashboard: { name: d.name }
+      }.to change{ Dashboard.count }.by(1)
+      expect(Dashboard.last.permalink).to eq(true)
+    end
+
     it "clones the dashboard given a source_id" do
       d = Dashboard.new_with_slug(name: "example dash", dashboard_json: @sample_dashboard_json)
       d.save!

--- a/spec/factories/dashboard_factory.rb
+++ b/spec/factories/dashboard_factory.rb
@@ -10,6 +10,13 @@ FactoryGirl.define do
       SlugMaker.slug(name)
     end
 
+    trait :permalink do
+      permalink true
+      sequence :name do |n|
+        "Permalink dashboard #{n}"
+      end
+    end
+
     dashboard_json File.read('./spec/support/sample_json/1_expression_dashboard_json')
 
     trait :two_expressions do

--- a/spec/features/dashboards_spec.rb
+++ b/spec/features/dashboards_spec.rb
@@ -29,6 +29,25 @@ feature "Dashboard", js: true do
     end
   end
 
+  describe "permalink dashboards" do
+    scenario "creating a permalink dashboard" do
+      dashboard = FactoryGirl.create(:dashboard)
+      visit dashboard_slug_path dashboard.slug
+      expect {
+        find('#global_controls .glyphicon-link').click
+        expect(page).to have_content('Dashboard Permalink')
+      }.to change { Dashboard.count }.by(1)
+      expect(Dashboard.last.permalink).to eq(true)
+    end
+
+    scenario "visiting a permalink dashboard" do
+      dashboard = FactoryGirl.create(:dashboard, :permalink)
+      visit dashboard_slug_path dashboard.slug
+      expect(page).to have_no_css('#global_controls .glyphicon-link')
+      expect(page).to have_no_content('Save Changes')
+    end
+  end
+
   scenario "creating the dashboard" do
     directory = FactoryGirl.create :directory
     visit new_dashboard_path

--- a/spec/features/directories_spec.rb
+++ b/spec/features/directories_spec.rb
@@ -15,6 +15,12 @@ feature "Directory", js: true do
       expect(page).to have_content(/unassigned dashboards/i)
     end
 
+    scenario "permalink dashboards don't appear" do
+      d = FactoryGirl.create :dashboard, :permalink
+      visit directories_path
+      expect(page).to have_no_content(/#{d.name}/i)
+    end
+
     scenario "with assigned dashboards" do
       FactoryGirl.create :directory, dashboard_ids: Dashboard.pluck(:id)
       visit current_path

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -18,6 +18,10 @@ describe Dashboard do
       d = Dashboard.new_with_slug(name: "dashboard")
       expect(d).to_not be_valid
     end
+    it "makes permalink dashboards" do
+      d = Dashboard.new_permalink(name: "static dashboard")
+      expect(d).to be_valid
+    end
   end
 
   context "scopes" do


### PR DESCRIPTION
requested in #288 

question: keep url updated is still an option. do we want this to be removed?