### PR TITLE
Only store disabled series for graph.

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -388,8 +388,11 @@ angular.module("Prometheus.directives").directive('graphChart', ["$location", "W
         if (!rsGraph) {
           return;
         }
+        scope.graphSettings.disabledSeries = {};
         rsGraph.series.forEach(function(s) {
-          scope.graphSettings.disabledSeries[s.uniqName] = s.disabled ? true : false;
+          if (s.disabled) {
+            scope.graphSettings.disabledSeries[s.uniqName] = true;
+          }
         });
       }
 


### PR DESCRIPTION
Fixes regression in which the state of each time series (disabled or not) was being stored in the graph object.