### PR TITLE
Drag zoom in breakout

### DIFF
--- a/app/assets/javascripts/angular/controllers/dashboard_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/dashboard_ctrl.js
@@ -205,22 +205,6 @@ angular.module("Prometheus.controllers")
     $scope.globalConfig.vars = vars;
   }, true);
 
-  $scope.$watch("globalConfig", function(newConfig, oldConfig) {
-    if (newConfig === oldConfig) {
-      return
-    }
-    if (newConfig.range) {
-      $location.search("range", newConfig.range)
-    } else {
-      $location.search("range", null);
-    }
-    if (newConfig.endTime) {
-      $location.search("until", (new Date(newConfig.endTime)).toISOString())
-    } else {
-      $location.search("until", null);
-    }
-  }, true);
-
   $scope.$watch('globalConfig.tags', function() {
     $scope.widgets.forEach(function(w) {
       if (w.type === "graph") {

--- a/app/assets/javascripts/angular/resources/shared_graph_behavior.js
+++ b/app/assets/javascripts/angular/resources/shared_graph_behavior.js
@@ -110,6 +110,22 @@ angular.module("Prometheus.services").factory("SharedGraphBehavior", ["$http", "
       });
     });
 
+    $scope.$watch("globalConfig", function(newConfig, oldConfig) {
+      if (newConfig === oldConfig) {
+        return
+      }
+      if (newConfig.range) {
+        $location.search("range", newConfig.range)
+      } else {
+        $location.search("range", null);
+      }
+      if (newConfig.endTime) {
+        $location.search("until", (new Date(newConfig.endTime)).toISOString())
+      } else {
+        $location.search("until", null);
+      }
+    }, true);
+
     $scope.refreshDashboard = function() {
       $scope.$broadcast('refreshDashboard');
     };

--- a/spec/javascripts/angular/resources/shared_graph_behavior_spec.js
+++ b/spec/javascripts/angular/resources/shared_graph_behavior_spec.js
@@ -11,23 +11,82 @@ describe('SharedGraphBehavior', function() {
     sgb = _SharedGraphBehavior_;
   }));
 
-  describe('url variables', function() {
-    beforeEach(function() {
-      $scope.globalConfig = {
-        numColumns: 2,
-        endTime: 'configEndTime',
-        range: 'configRange',
-        aspectRatio: 0.75,
-        theme: 'dark_theme',
-        vars: {},
-      };
-      $scope.widgets = [
-        {range: 'widgetRange', endTime: 'widgetEndTime'},
-        {range: 'widgetRange', endTime: 'widgetEndTime'},
-        {range: 'widgetRange', endTime: 'widgetEndTime'},
-      ];
-    });
+  beforeEach(function() {
+    $scope.globalConfig = {
+      numColumns: 2,
+      endTime: 'configEndTime',
+      range: 'configRange',
+      aspectRatio: 0.75,
+      theme: 'dark_theme',
+      vars: {},
+    };
+    $scope.widgets = [
+      {range: 'widgetRange', endTime: 'widgetEndTime'},
+      {range: 'widgetRange', endTime: 'widgetEndTime'},
+      {range: 'widgetRange', endTime: 'widgetEndTime'},
+    ];
+  });
 
+  describe('globalConfig', function() {
+    describe('$location', function() {
+      it('doesnt change $location on initial load', function() {
+        sgb($scope, $scope.globalConfig);
+        $scope.$digest();
+        expect($location.search().range).toEqual(undefined);
+        expect($location.search().until).toEqual(undefined);
+      });
+
+      describe('removing params', function() {
+        var range;
+        var date;
+        beforeEach(function() {
+          date = (new Date()).toISOString();
+          range = '300s';
+          $location.search('range', range);
+          $location.search('until', date);
+        });
+
+        it('range query param', function() {
+          sgb($scope, $scope.globalConfig);
+          $scope.$digest();
+          expect($location.search().range).toEqual(range);
+          $scope.globalConfig.range = '';
+          $scope.$digest();
+          expect($location.search().range).toEqual(undefined);
+        });
+
+        it('endTime query param', function() {
+          sgb($scope, $scope.globalConfig);
+          $scope.$digest();
+          expect($location.search().until).toEqual(date);
+          $scope.globalConfig.endTime = '';
+          $scope.$digest();
+          expect($location.search().until).toEqual(undefined);
+        });
+      });
+
+      describe('adding params', function() {
+        it('range query param', function() {
+          sgb($scope, $scope.globalConfig);
+          $scope.$digest();
+          $scope.globalConfig.range = '300s';
+          $scope.$digest();
+          expect($location.search().range).toEqual('300s');
+        });
+
+        it('until query param', function() {
+          sgb($scope, $scope.globalConfig);
+          $scope.$digest();
+          var d = new Date();
+          $scope.globalConfig.endTime = d.getTime(); // UNIX timestamp.
+          $scope.$digest();
+          expect($location.search().until).toEqual(d.toISOString());
+        });
+      });
+    });
+  });
+
+  describe('url variables', function() {
     it('sets range, endTime on globalConfig and widgets when set in url', function() {
       var date = '2015-02-03T19:11:59.350Z';
       var dateMS = Date.parse(date);
@@ -35,7 +94,7 @@ describe('SharedGraphBehavior', function() {
       $location.search('range', range);
       $location.search('until', date);
       sgb($scope, $scope.globalConfig);
-      $scope.$apply();
+      $scope.$digest();
       expect($scope.globalConfig.endTime).toEqual(dateMS);
       expect($scope.globalConfig.range).toEqual(range);
       $scope.widgets.forEach(function(w) {
@@ -48,7 +107,7 @@ describe('SharedGraphBehavior', function() {
       $location.search('range', null);
       $location.search('until', null);
       sgb($scope, $scope.globalConfig);
-      $scope.$apply();
+      $scope.$digest();
       expect($scope.globalConfig.endTime).toEqual('configEndTime');
       expect($scope.globalConfig.range).toEqual('configRange');
       $scope.widgets.forEach(function(w) {


### PR DESCRIPTION
drag-zoom in a breakout graph currently correctly zooms in on the dragged area, but the endTime and range are not updated. when the request is fired for more detailed visuals, it is sent with the old endTime and range, which causes the graph to return to its pre-zoomed state.

this fixes that behavior, as well as testing that query params for range and until are correctly removed and added to the url when the global config object is changed. changing the global config object is part of the callback from the drag zoom, and the changes propagate from there to the url.

depends on #321 