### PR TITLE
Refresh frame with updated endtime/range values.

### DIFF
--- a/app/assets/javascripts/angular/controllers/frame_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/frame_ctrl.js
@@ -92,7 +92,6 @@ angular.module("Prometheus.controllers").controller('FrameCtrl', ["$scope",
         return o.key;
       }
     }).join("&");
-    $scope.frame.escapedURL = VariableInterpolator(parser.href, $scope.vars);
     $scope.frame.url = unescape(parser.href);
   }
   initFrameURL();

--- a/app/assets/javascripts/angular/directives/frame.js.erb
+++ b/app/assets/javascripts/angular/directives/frame.js.erb
@@ -17,19 +17,6 @@ angular.module("Prometheus.directives").directive('inlineFrame', ["$sce", "Varia
         return WidgetHeightCalculator(element.find(".js_widget_wrapper")[0], scope.aspectRatio);
       }
 
-      scope.refreshFrame = function() {
-        var frame = element.find('.frame_container');
-        frame.html(frame.html());
-      };
-
-      var a = ['frame.url', 'frame.range', 'frame.endTime', 'refreshCounter', 'frame.graphite'];
-      a.forEach(function(w) {
-        scope.$watch(w, regenFrame);
-      });
-      ['refreshDashboard', 'redrawGraphs'].forEach(function(m) {
-        scope.$on(m, regenFrame);
-      });
-
       // In order for zoom-out to work correctly on dashboards with iframes,
       // the iframe needs to be completely reconstructed on each refresh.
       // Modifying an iframe's src attribute, as in the previous implementation,
@@ -37,17 +24,21 @@ angular.module("Prometheus.directives").directive('inlineFrame', ["$sce", "Varia
       // out as it takes an additional history.back() execution to traverse the
       // history state added by modifying an iframe's src.
       // http://khaidoan.wikidot.com/iframe-and-browser-history
-      function regenFrame() {
-        if (!scope.frame.escapedURL) {
-          return;
-        }
-        var url = scope.frame.escapedURL.slice();
-        delete scope.frame.escapedURL;
+      scope.refreshFrame = function() {
+        var url = VariableInterpolator(scope.frame.url, scope.vars);
         var trustedURL = $sce.trustAsResourceUrl(buildFrameURL(url));
         var frame = element.find('.frame_container');
         frame.height(frameHeight());
         frame.html('<iframe src="'+ trustedURL +'" class="frame_iframe" marginwidth="0" scrolling="no"></iframe>');
-      }
+      };
+
+      var a = ['frame.url', 'frame.range', 'frame.endTime', 'refreshCounter', 'frame.graphite'];
+      a.forEach(function(w) {
+        scope.$watch(w, scope.refreshFrame);
+      });
+      ['refreshDashboard', 'redrawGraphs'].forEach(function(m) {
+        scope.$on(m, scope.refreshFrame);
+      });
 
       function buildFrameURL(url) {
         var parser = document.createElement('a');

--- a/spec/javascripts/angular/controllers/frame_ctrl_spec.js
+++ b/spec/javascripts/angular/controllers/frame_ctrl_spec.js
@@ -19,10 +19,6 @@ describe('FrameCtrl', function() {
     it('doesnt escape or interpolate the displayed frame url', function() {
       expect($scope.frame.url).toEqual(url);
     });
-
-    it('escapes and interpolates the iframe src url', function() {
-      expect($scope.frame.escapedURL).toEqual('http://graphite/render/?target=alias(stats_counts.statsd.packets_received,%20%22alias name:%20derp%22)');
-    });
   });
 
   describe('generating frame components', function() {


### PR DESCRIPTION
The refresh was aborting early in the previous commit, causing changes in just endtime/range not to be added to the url. Now, instead of a transient url var, the scope stores the current escaped url. Updated fields e.g. height width from until will be written to this url, which is used as the source for the iframe.

@juliusv 