### PR TITLE
Fix: Rails 4 upgrade; added 'bin' into source control.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 .ruby-gemset
 #.ruby-version
 
-/bin
 /build
 /vendor/bundle
 /system

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../../config/application',  __FILE__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require_relative '../config/boot'
+require 'rake'
+Rake.application.run


### PR DESCRIPTION
Hi,

A fresh clone of promdash fails to start a rails server. After a `bundle install` an attempt to run `bundle exec rails server` will throw a usage error of `rails new`. I believe this is because the loader failed to find the appropriate files and thus deemed the root dir was not a rails app dir.
As per the comments in https://github.com/rails/rails/blob/master/railties/lib/rails/app_rails_loader.rb I've 'updated' to rails 4, by including these bin files.
Now I can run a local rails server.

These are my application versions:
$ gem -v
2.2.2
$ bundle -v
Bundler version 1.7.13
$ rails -v
Rails 4.1.7

OS: Ubuntu 14.10

If this isn't the root cause or an acceptable fix, feel free to ignore/reject this PR.

Stefano