### PR TITLE
Update base packages and cleanup apt cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM       ubuntu:13.10
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
 ENV        RAILS_ENV production
 
-RUN        apt-get update && apt-get install -yq \
-           ruby2.0 ruby2.0-dev gcc make g++ libmysqlclient-dev
+RUN        apt-get update && apt-get -qq upgrade && apt-get install -yq \
+           ruby2.0 ruby2.0-dev gcc make g++ libmysqlclient-dev && apt-get clean
 RUN        gem install bundler
 
 WORKDIR    /promdash


### PR DESCRIPTION
I noticed when building this that it pulled in an insecure version of OpenSSL from ubuntu:13.10 - It's important to make sure that such packages are kept up to date so adding an apt-get upgrade at the start of the dockerfile will prevent this.

An additional suggestion would be to switch to a Debian base image rather than Ubuntu - Debian's packages are better maintained and generally have faster security patching - for newer packages you can also include Debian backports sources.