### PR TITLE
Add missing gems for PostgreSQL support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 gem 'rails', '4.1.7'
 
 gem 'mysql2'
+gem 'pg'
+gem 'activerecord-postgresql-adapter'
 
 gem 'active_model_serializers'
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem 'rails', '4.1.7'
 
 gem 'mysql2'
 gem 'pg'
-gem 'activerecord-postgresql-adapter'
 
 gem 'active_model_serializers'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,6 @@ GEM
       activemodel (= 4.1.7)
       activesupport (= 4.1.7)
       arel (~> 5.0.0)
-      activerecord-postgresql-adapter (0.0.1)
-        pg
     activesupport (4.1.7)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,8 @@ GEM
       activemodel (= 4.1.7)
       activesupport (= 4.1.7)
       arel (~> 5.0.0)
+      activerecord-postgresql-adapter (0.0.1)
+        pg
     activesupport (4.1.7)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
@@ -84,6 +86,7 @@ GEM
     mysql2 (0.3.13)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
+    pg (0.18.1)
     phantomjs (1.9.8.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)


### PR DESCRIPTION
As per https://github.com/prometheus/promdash/issues/332

I'm actually a little unsure if activerecord-postgresql-adapter is truly required, or if pg is enough?