### PR TITLE
Update makefile and include postgresql during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILDDIR=build
 RUBY_VERSION=$(shell cat .ruby-version | perl -ne "chomp and print")
 RUBY_TAR=ruby-$(RUBY_VERSION).tar.gz
 RUBY_SRC=$(BUILDDIR)/ruby-$(RUBY_VERSION)
-RUBY_URL=ftp://ftp.ruby-lang.org/pub/ruby/2.0/$(RUBY_TAR)
+RUBY_URL?=ftp://ftp.ruby-lang.org/pub/ruby/2.0/$(RUBY_TAR)
 RUBY_BIN=$(DESTDIR)/bin/ruby
 
 build: Gemfile.lock $(RUBY_BIN)

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,16 @@ RUBY_SRC=$(BUILDDIR)/ruby-$(RUBY_VERSION)
 RUBY_URL=ftp://ftp.ruby-lang.org/pub/ruby/2.0/$(RUBY_TAR)
 RUBY_BIN=$(DESTDIR)/bin/ruby
 
-$(DESTDIR):
-	mkdir -p $@
+build: Gemfile.lock $(RUBY_BIN)
+	bin/env gem install bundler --bindir bin/ --no-document
+	bin/env bin/bundle install --deployment --binstubs --without="development test migration postgresql"
+	rm -rf public/assets/*
+	bin/env bin/bundle exec rake assets:precompile
+
+clean:
+	rm -rf $(BUILDDIR) $(DESTDIR)
+
+.PHONY: build clean
 
 $(RUBY_SRC)/Makefile: .ruby-version
 	mkdir -p $(RUBY_SRC)
@@ -21,11 +29,3 @@ $(RUBY_SRC)/Makefile: .ruby-version
 $(RUBY_BIN): $(RUBY_SRC)/Makefile
 	cd $(RUBY_SRC) && make && make install
 
-build: Gemfile.lock $(RUBY_BIN)
-	bin/env gem install bundler --bindir bin/ --no-document
-	bin/env bin/bundle install --deployment --binstubs --without="development test migration"
-	rm -rf public/assets/*
-	bin/env bin/bundle exec rake assets:precompile
-
-clean:
-	git clean -f -d -x


### PR DESCRIPTION
The Makefile is a hard dependency of SoundCloud's usage so far. This
change should ensure that it still works after the recent postgresql
addition. A later change should probably allow people to use the
Make targets also when using postgresql.

@stuartnelson3 Please test the build with this branch and merge if successful. 