### PR TITLE
Encode frame query parameters properly

### DIFF
--- a/app/assets/javascripts/angular/directives/frame.js.erb
+++ b/app/assets/javascripts/angular/directives/frame.js.erb
@@ -1,4 +1,13 @@
-angular.module("Prometheus.directives").directive('inlineFrame', ["$sce", "VariableInterpolator", "GraphiteTimeConverter", "WidgetHeightCalculator", function($sce, VariableInterpolator, GraphiteTimeConverter, WidgetHeightCalculator) {
+angular.module("Prometheus.directives").directive('inlineFrame', ["$sce",
+                                                  "VariableInterpolator",
+                                                  "GraphiteTimeConverter",
+                                                  "WidgetHeightCalculator",
+                                                  "URLParser",
+                                                  function($sce,
+                                                    VariableInterpolator,
+                                                    GraphiteTimeConverter,
+                                                    WidgetHeightCalculator,
+                                                    URLParser) {
   var FRAME_CONTAINER_PADDING = 10;
   var FRAME_BACKGROUND_COLOR = '%23191919';
   return {
@@ -41,46 +50,24 @@ angular.module("Prometheus.directives").directive('inlineFrame', ["$sce", "Varia
       });
 
       function buildFrameURL(url) {
-        var parts = url.split('?'),
-        var path = parts[0];
-        var query = parts[1] ? parts[1].split('&') : [];
+        var parser = URLParser(url);
 
         if (scope.frame.graphite) {
-          query = parseGraphiteQuery(query);
+          setGraphiteParams(parser);
         }
 
-        query.push('decache=' + scope.refreshCounter);
-        query = query.map(function (component) {
-          return component.split('=').map(encodeURIComponent).join('=');
-        });
+        parser.setQueryParam('decache', scope.refreshCounter);
 
-        return [path, query.join('&')].join('?');
+        return parser.stringify();
       }
 
-      function parseGraphiteQuery(query) {
-        var fields = {};
-        var targets = [];
-
-        query.forEach(function(f) {
-          var s = f.split('=');
-          // If there are more than 1 target in the query string, they get overridden.
-          // So we can't put them in the fields object.
-          if (s[0] !== 'target') {
-            fields[s.shift()] = s.join('=');
-          } else {
-            targets.push(f);
-          }
-        });
-
+      function setGraphiteParams(parser) {
         var height = frameHeight();
-
-        return [
-          'height=' + height,
-          'width=' + ((height / scope.aspectRatio) - FRAME_CONTAINER_PADDING),
-          'from=' + GraphiteTimeConverter.graphiteFrom(scope.frame.range, scope.frame.endTime),
-          'until=' + GraphiteTimeConverter.graphiteUntil(scope.frame.endTime),
-          'bgcolor=' + FRAME_BACKGROUND_COLOR
-        ].concat(targets);
+        parser.setQueryParam('height', height);
+        parser.setQueryParam('width', ((height / scope.aspectRatio) - FRAME_CONTAINER_PADDING));
+        parser.setQueryParam('from', GraphiteTimeConverter.graphiteFrom(scope.frame.range, scope.frame.endTime));
+        parser.setQueryParam('until', GraphiteTimeConverter.graphiteUntil(scope.frame.endTime));
+        parser.setQueryParam('bgcolor', FRAME_BACKGROUND_COLOR);
       }
     }
   };

--- a/app/assets/javascripts/angular/directives/frame.js.erb
+++ b/app/assets/javascripts/angular/directives/frame.js.erb
@@ -41,20 +41,27 @@ angular.module("Prometheus.directives").directive('inlineFrame', ["$sce", "Varia
       });
 
       function buildFrameURL(url) {
-        var parser = document.createElement('a');
-        parser.href = url;
+        var parts = url.split('?'),
+        var path = parts[0];
+        var query = parts[1] ? parts[1].split('&') : [];
+
         if (scope.frame.graphite) {
-          return parseGraphiteURL(parser);
+          query = parseGraphiteQuery(query);
         }
-        parser.search = parser.search + '&decache=' + scope.refreshCounter;
-        return parser.href;
+
+        query.push('decache=' + scope.refreshCounter);
+        query = query.map(function (component) {
+          return component.split('=').map(encodeURIComponent).join('=');
+        });
+
+        return [path, query.join('&')].join('?');
       }
 
-      function parseGraphiteURL(parser) {
-        var queryStringComponents = parser.search.substring(1).split('&');
+      function parseGraphiteQuery(query) {
         var fields = {};
         var targets = [];
-        queryStringComponents.forEach(function(f) {
+
+        query.forEach(function(f) {
           var s = f.split('=');
           // If there are more than 1 target in the query string, they get overridden.
           // So we can't put them in the fields object.
@@ -66,13 +73,14 @@ angular.module("Prometheus.directives").directive('inlineFrame', ["$sce", "Varia
         });
 
         var height = frameHeight();
-        fields.height = height;
-        fields.width = (height / scope.aspectRatio) - FRAME_CONTAINER_PADDING;
-        fields.from = GraphiteTimeConverter.graphiteFrom(scope.frame.range, scope.frame.endTime);
-        fields.until = GraphiteTimeConverter.graphiteUntil(scope.frame.endTime);
-        fields.bgcolor = FRAME_BACKGROUND_COLOR;
-        parser.search = '?' + decodeURI($.param(fields)) + '&' + targets.join('&') + '&decache=' + scope.refreshCounter;
-        return parser.href;
+
+        return [
+          'height=' + height,
+          'width=' + ((height / scope.aspectRatio) - FRAME_CONTAINER_PADDING),
+          'from=' + GraphiteTimeConverter.graphiteFrom(scope.frame.range, scope.frame.endTime),
+          'until=' + GraphiteTimeConverter.graphiteUntil(scope.frame.endTime),
+          'bgcolor=' + FRAME_BACKGROUND_COLOR
+        ].concat(targets);
       }
     }
   };

--- a/spec/javascripts/angular/controllers/frame_ctrl_spec.js
+++ b/spec/javascripts/angular/controllers/frame_ctrl_spec.js
@@ -1,7 +1,8 @@
 describe('FrameCtrl', function() {
   var $controller;
   var $scope;
-  beforeEach(inject(function(_$controller_, _VariableInterpolator_, $rootScope){
+
+  beforeEach(inject(function(_$controller_, $rootScope){
     $controller = _$controller_;
     $scope = $rootScope.$new(true);
     $scope.frame = {};

--- a/spec/javascripts/angular/services/url_config_spec.js
+++ b/spec/javascripts/angular/services/url_config_spec.js
@@ -1,0 +1,89 @@
+describe('UrlConfig', function() {
+
+  describe('URLParser', function () {
+    var URLParser;
+
+    beforeEach(inject(function(_URLParser_) {
+       URLParser = _URLParser_;
+    }));
+
+    it('can parse urls without any query paramters or hash', function() {
+      var url = 'http://www.soundcloud.com/some/path';
+      var parsed = URLParser(url);
+      expect(parsed.path).toEqual(url);
+      expect(parsed.stringify()).toEqual(url);
+    });
+
+    it('can parse urls with query parameters and a hash', function() {
+      var url = 'https://www.youtube.com/watch?v=deadbeef#t=1s';
+      var parsed = URLParser(url);
+      expect(parsed.path).toEqual('https://www.youtube.com/watch');
+      expect(parsed.getQueryParams()).toEqual({
+        v: 'deadbeef'
+      });
+      expect(parsed.hash).toEqual({
+        t: '1s'
+      });
+      expect(parsed.stringify()).toEqual(url);
+    });
+
+    it('can treat a hash (#) as part of a query parameter', function() {
+      var url = 'http://graphite-example.com/render?width=370&from=-3hours&until=-&height=250&target=color(alias(drawAsInfinite(some.event),""),"#663399")&yMinRight=0&title&hideLegend=false'
+      var parsed = URLParser(url, {ignoreHash: true});
+      expect(parsed.path).toEqual('http://graphite-example.com/render');
+      expect(parsed.getQueryParams()).toEqual({
+        width: '370',
+        from: '-3hours',
+        until: '-',
+        height: '250',
+        target: 'color(alias(drawAsInfinite(some.event),""),"#663399")',
+        yMinRight: '0',
+        title: '',
+        hideLegend: 'false'
+      });
+      expect(parsed.stringify(false)).toEqual(url);
+    });
+
+    it('can add query parameters', function() {
+      var url = 'http://graphite-example.com/render?width=370&from=-3hours';
+      var parsed = URLParser(url);
+      parsed.setQueryParam('until', '-');
+      expect(parsed.getQueryParams()).toEqual({
+        width: '370',
+        from: '-3hours',
+        until: '-'
+      });
+    });
+
+    it('can remove query parameters', function() {
+      var url = 'http://graphite-example.com/render?width=370&from=-3hours';
+      var parsed = URLParser(url);
+      parsed.removeQueryParam('from');
+      expect(parsed.getQueryParams()).toEqual({
+        width: '370'
+      });
+    });
+
+    it('can add hash parameters', function() {
+      var url = 'http://graphite-example.com/render#width=370&from=-3hours';
+      var parsed = URLParser(url);
+      parsed.setHashParam('until', '-');
+      expect(parsed.getHashParams()).toEqual({
+        width: '370',
+        from: '-3hours',
+        until: '-'
+      });
+    });
+
+    it('can remove hash parameters', function() {
+      var url = 'http://graphite-example.com/render#width=370&from=-3hours';
+      var parsed = URLParser(url);
+      parsed.removeHashParam('from');
+      expect(parsed.getHashParams()).toEqual({
+        width: '370'
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
The existing query parameter encoding was OK, but failed for a critical use-case:
graphite URLs containing colors that looked like #00AA00. The # character was causing
the URL to be truncated, as it has a special meaning in a URL.

The fix was not simple, because we display the unescaped URL to users (why?).
We are now manually parsing the query string instead of relying on shoving it into
an anchor tag. For our purposes, it should be fine; promdash doesn't do much w/ this.