### PR TITLE
Allow server URLs with custom paths or no trailing slash.

### DIFF
--- a/app/assets/javascripts/angular/controllers/pie_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/pie_ctrl.js
@@ -1,9 +1,11 @@
 angular.module("Prometheus.controllers").controller('PieCtrl',
                                                     ["$scope", "$http",
                                                       "SharedWidgetSetup",
+                                                      "URLGenerator",
                                                       function($scope,
                                                                $http,
-                                                               SharedWidgetSetup) {
+                                                               SharedWidgetSetup,
+                                                               URLGenerator) {
   SharedWidgetSetup($scope);
   $scope.errorMessages = [];
 
@@ -15,10 +17,7 @@ angular.module("Prometheus.controllers").controller('PieCtrl',
       return;
     }
     $scope.requestInFlight = true;
-    var url = document.createElement('a');
-    url.href = server.url;
-    url.pathname = url.pathname.replace(/\/?$/, '/api/query');
-    $http.get(url.href, {
+    $http.get(URLGenerator(server.url, '/api/query'), {
       params: {
         expr: exp.expression
       }

--- a/app/assets/javascripts/angular/controllers/pie_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/pie_ctrl.js
@@ -17,7 +17,7 @@ angular.module("Prometheus.controllers").controller('PieCtrl',
     $scope.requestInFlight = true;
     var url = document.createElement('a');
     url.href = server.url;
-    url.pathname = 'api/query';
+    url.pathname = url.pathname.replace(/\/?$/, '/api/query');
     $http.get(url.href, {
       params: {
         expr: exp.expression

--- a/app/assets/javascripts/angular/services/graph_refresher.js
+++ b/app/assets/javascripts/angular/services/graph_refresher.js
@@ -2,16 +2,15 @@ angular.module("Prometheus.services").factory('GraphRefresher',
                                               ["$http",
                                                "$q",
                                                "VariableInterpolator",
+                                               "URLGenerator",
                                                function($http,
                                                         $q,
-                                                        VariableInterpolator) {
+                                                        VariableInterpolator,
+                                                        URLGenerator) {
   return function($scope) {
     function loadGraphData(idx, expression, server, expressionID, endTime, rangeSeconds, step) {
       var deferred = $q.defer();
-      var url = document.createElement('a');
-      url.href = server.url;
-      url.pathname = url.pathname.replace(/\/?$/, '/api/query_range');
-      $http.get(url.href, {
+      $http.get(URLGenerator(server.url, '/api/query_range'), {
         params: {
           expr: expression,
           range: rangeSeconds,

--- a/app/assets/javascripts/angular/services/graph_refresher.js
+++ b/app/assets/javascripts/angular/services/graph_refresher.js
@@ -10,7 +10,7 @@ angular.module("Prometheus.services").factory('GraphRefresher',
       var deferred = $q.defer();
       var url = document.createElement('a');
       url.href = server.url;
-      url.pathname = 'api/query_range';
+      url.pathname = url.pathname.replace(/\/?$/, '/api/query_range');
       $http.get(url.href, {
         params: {
           expr: expression,

--- a/app/assets/javascripts/angular/services/metric_names_querier.js
+++ b/app/assets/javascripts/angular/services/metric_names_querier.js
@@ -8,7 +8,7 @@ angular.module("Prometheus.services").factory('MetricNamesQuerier', ["$http", fu
     }
     var url = document.createElement('a');
     url.href = serverURL;
-    url.pathname = 'api/metrics';
+    url.pathname = url.pathname.replace(/\/?$/, '/api/metrics');
     $http.get(url.href).success(function(metricNames) {
       metricNamesCache[serverID] = metricNames;
       scope.metricNames = metricNames;

--- a/app/assets/javascripts/angular/services/metric_names_querier.js
+++ b/app/assets/javascripts/angular/services/metric_names_querier.js
@@ -1,4 +1,4 @@
-angular.module("Prometheus.services").factory('MetricNamesQuerier', ["$http", function($http) {
+angular.module("Prometheus.services").factory('MetricNamesQuerier', ["$http", "URLGenerator", function($http, URLGenerator) {
   var metricNamesCache = {};
 
   return function(serverID, serverURL, scope) {
@@ -6,10 +6,7 @@ angular.module("Prometheus.services").factory('MetricNamesQuerier', ["$http", fu
       scope.metricNames = metricNamesCache[serverID];
       return;
     }
-    var url = document.createElement('a');
-    url.href = serverURL;
-    url.pathname = url.pathname.replace(/\/?$/, '/api/metrics');
-    $http.get(url.href).success(function(metricNames) {
+    $http.get(URLGenerator(serverURL, '/api/metrics')).success(function(metricNames) {
       metricNamesCache[serverID] = metricNames;
       scope.metricNames = metricNames;
       return;

--- a/app/assets/javascripts/angular/services/url_generator.js
+++ b/app/assets/javascripts/angular/services/url_generator.js
@@ -1,0 +1,8 @@
+angular.module("Prometheus.services").factory('URLGenerator', [function() {
+  return function(url, path) {
+    var a = document.createElement('a');
+    a.href = url;
+    a.pathname = a.pathname.replace(/\/?$/, path);
+    return a.href;
+  };
+}]);

--- a/spec/javascripts/angular/services/url_generator_spec.js
+++ b/spec/javascripts/angular/services/url_generator_spec.js
@@ -1,0 +1,27 @@
+//= require spec_helper
+describe('URLGenerator', function() {
+  var urlGenerator;
+  beforeEach(inject(function(_URLGenerator_) {
+    urlGenerator = _URLGenerator_;
+  }));
+
+  it('allows urls with custom paths, no trailing slash', function() {
+    ['http://promdash.server.com/prometheus', 'http://promdash.com'].forEach(function(s) {
+      ['/api/query_range', '/api/query', '/api/metrics', '/arbitrary/endpoint'].forEach(function(ep) {
+        var s = 'http://promdash.server.com/prometheus';
+        var url = urlGenerator(s, ep);
+        expect(url).toEqual(s + ep);
+      });
+    });
+  });
+
+  it('allows urls with custom paths, with trailing slash', function() {
+    ['http://promdash.server.com/prometheus/', 'http://promdash.com/'].forEach(function(s) {
+      ['/api/query_range', '/api/query', '/api/metrics', '/arbitrary/endpoint'].forEach(function(ep) {
+        var s = 'http://promdash.server.com/prometheus/';
+        var url = urlGenerator(s, ep);
+        expect(url).toEqual(s.substring(0, s.length - 1) + ep);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This enables people to use PromDash behind a proxy with a custom path,
like `http://myproxy/prometheus`.