### PR TITLE
add ignoreHash option to include all colors in colorList

### DIFF
--- a/app/assets/javascripts/angular/controllers/frame_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/frame_ctrl.js
@@ -58,7 +58,7 @@ angular.module("Prometheus.controllers").controller('FrameCtrl', ["$scope",
 
   $scope.generateFrameComponents = function() {
     // This URL should already be unescaped
-    var parser = URLParser($scope.frame.url);
+    var parser = URLParser($scope.frame.url, {ignoreHash: $scope.frame.graphite});
     var queryParams = parser.getQueryParams();
     $scope.frameComponents = Object.keys(queryParams).reduce(function(components, key) {
       // possible to have array of values for any key
@@ -86,7 +86,7 @@ angular.module("Prometheus.controllers").controller('FrameCtrl', ["$scope",
   }, true);
 
   function initFrameURL() {
-    var parser = URLParser($scope.frame.url);
+    var parser = URLParser($scope.frame.url, {ignoreHash: $scope.frame.graphite});
     var previousParams = Object.keys(parser.getQueryParams());
     var newParams = $scope.frameComponents.reduce(function (params, component) {
       params[component.key] = params[component.key] ? [].concat(params[component.key], component.value) : component.value;

--- a/app/assets/javascripts/angular/directives/frame.js.erb
+++ b/app/assets/javascripts/angular/directives/frame.js.erb
@@ -50,7 +50,7 @@ angular.module("Prometheus.directives").directive('inlineFrame', ["$sce",
       });
 
       function buildFrameURL(url) {
-        var parser = URLParser(url);
+        var parser = URLParser(url, {ignoreHash: scope.frame.graphite});
 
         if (scope.frame.graphite) {
           setGraphiteParams(parser);

--- a/spec/javascripts/angular/services/url_config_spec.js
+++ b/spec/javascripts/angular/services/url_config_spec.js
@@ -28,7 +28,7 @@ describe('UrlConfig', function() {
     });
 
     it('can treat a hash (#) as part of a query parameter', function() {
-      var url = 'http://graphite-example.com/render?width=370&from=-3hours&until=-&height=250&target=color(alias(drawAsInfinite(some.event),""),"#663399")&yMinRight=0&title&hideLegend=false'
+      var url = 'http://graphite-example.com/render?width=370&from=-3hours&until=-&height=250&target=color(alias(drawAsInfinite(some.event),""),"#663399")&yMinRight=0&title&hideLegend=false';
       var parsed = URLParser(url, {ignoreHash: true});
       expect(parsed.path).toEqual('http://graphite-example.com/render');
       expect(parsed.getQueryParams()).toEqual({
@@ -52,6 +52,14 @@ describe('UrlConfig', function() {
         width: '370',
         from: '-3hours',
         until: '-'
+      });
+    });
+
+    it('correctly parses a colorList', function() {
+      var url = 'http://graphite-example.com/render?colorList=#38AFEB,#EB3838,#38EB38,#EB38DC';
+      var parsed = URLParser(url, {ignoreHash: true});
+      expect(parsed.getQueryParams()).toEqual({
+        colorList: '#38AFEB,#EB3838,#38EB38,#EB38DC'
       });
     });
 


### PR DESCRIPTION
@diurnalist see the test added. the issue being seen was that users would have a list of colors, and the final hashtag was being set as `hashIndex` in the constructor.

instead of `http://graphite-example.com/render?colorList=#38AFEB,#EB3838,#38EB38,#EB38DC&decache=3`, the url was being stringified to
`http://graphite-example.com/render?colorList=#38AFEB,#EB3838,#38EB38,&decache=3#EB38DC` (and breaking)

Is this how I should handle this issue?