### PR TITLE
Fix double-escaping issue for multiple expressions.

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -40,8 +40,8 @@ angular.module("Prometheus.directives").directive('graphChart', [
               if ((lst || {}).name) {
                 s.name = VariableInterpolator(lst.name, s.labels);
               }
+              s.name = HTMLEscaper(s.name);
             }
-            s.name = HTMLEscaper(s.name);
           });
         });
       }

--- a/spec/features/graph/legend_spec.rb
+++ b/spec/features/graph/legend_spec.rb
@@ -58,6 +58,17 @@ feature "Graph legend", js: true do
         end
       end
     end
+
+    it "does not double-escape legend strings when there are multiple expressions" do
+      open_tab 'Legend Settings'
+      legend_inputs = all '.legend_string_input'
+      input1 = legend_inputs[0]
+      input2 = legend_inputs[1]
+
+      input1.set ''
+      input2.set ''
+      expect(page).to have_content "<b>bold</b><script>alert(1);</script>"
+    end
   end
 
   describe "one legend string" do


### PR DESCRIPTION
When there were multiple expressions configured for a graph, each legend
string would be escaped once for every expression, leading to
double-escaping or worse.