### PR TITLE
Configurable path prefix to run PromDash behind a proxy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     daemons (1.1.9)
     database_cleaner (0.9.1)
     diff-lcs (1.2.5)
-    entypo-rails (2.0.2)
+    entypo-rails (2.2.2)
       railties (>= 3.1, <= 5)
     erubis (2.7.0)
     eventmachine (1.0.3)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ can specify any kind of command as parameter to the Docker image:
 
     docker run -e DATABASE_URL=... prom/promdash ./bin/rake db:migrate
 
+### Deploy behind a reverse proxy
+
+To deploy PromDash behind a reverse proxy you can set a global path prefix
+using the environment variable `PROMDASH_PATH_PREFIX`. Once set all URLs will
+start with the given prefix.
+
 ### Deployment Checklist
 
 *Before* deploying a new version of PromDash, follow this checklist:

--- a/app/assets/javascripts/angular/controllers/dashboard_ctrl.js.erb
+++ b/app/assets/javascripts/angular/controllers/dashboard_ctrl.js.erb
@@ -32,7 +32,7 @@ angular.module("Prometheus.controllers")
       return;
     }
     $scope.generatingPermalink = true;
-    $http.post($window.location.origin + "/permalink", buildDashboardJSON()).then(function(payload) {
+    $http.post($window.location.origin + "<%= Rails.configuration.path_prefix %>permalink", buildDashboardJSON()).then(function(payload) {
       $scope.showPermalink = true;
       $scope.permalink = $window.location.origin + payload.data.url;
       var input = $("[ng-model=permalink]")[0];
@@ -189,7 +189,7 @@ angular.module("Prometheus.controllers")
 
   $scope.queryDirectory = function() {
     $scope.directoryForClone.id = $scope.directoryForClone.id || "unassigned";
-    $http.get('/directories/' + $scope.directoryForClone.id).then(function(payload) {
+    $http.get('<%= Rails.configuration.path_prefix %>directories/' + $scope.directoryForClone.id).then(function(payload) {
       $scope.dashboardNames = payload.data.dashboards;
       $scope.dashboardForClone = payload.data.dashboards.filter(function(d) {
         return d.name == dashboardName;
@@ -199,7 +199,7 @@ angular.module("Prometheus.controllers")
   };
 
   $scope.queryDashboard = function() {
-    $http.get('/dashboards/' + $scope.dashboardForClone.id + '/widgets').then(function(payload) {
+    $http.get('<%= Rails.configuration.path_prefix %>dashboards/' + $scope.dashboardForClone.id + '/widgets').then(function(payload) {
       $scope.dashboardWidgets = payload.data.widgets;
       $scope.widgetToClone = payload.data.widgets[0];
     });
@@ -210,7 +210,7 @@ angular.module("Prometheus.controllers")
     ModalService.toggleModal();
   };
 
-  $http.get('/directories.json').then(function(payload) {
+  $http.get('<%= Rails.configuration.path_prefix %>directories.json').then(function(payload) {
     $scope.directoryNames = payload.data.directories;
     $scope.directoryForClone = payload.data.directories.filter(function(d) {
       return d.name == directoryName;

--- a/app/assets/javascripts/angular/services/annotation_refresher.js.erb
+++ b/app/assets/javascripts/angular/services/annotation_refresher.js.erb
@@ -13,7 +13,7 @@ angular.module("Prometheus.services").factory('AnnotationRefresher', ["$http", "
       var until = Math.floor(graph.endTime || Date.now()) / 1000;
 
       tags.forEach(function(t) {
-        $http.get('/annotations', {
+        $http.get('<%= Rails.configuration.path_prefix %>annotations', {
           params: {
             'tags[]': t,
             until: until,

--- a/app/assets/javascripts/angular/services/widget_link_helper.js.erb
+++ b/app/assets/javascripts/angular/services/widget_link_helper.js.erb
@@ -1,7 +1,7 @@
 angular.module("Prometheus.services").factory('WidgetLinkHelper', ["$http", "InputHighlighter", function($http, InputHighlighter) {
   return {
     createLink: function(data) {
-      this.promise = $http.post('/w', data);
+      this.promise = $http.post('<%= Rails.configuration.path_prefix %>w', data);
       return this;
     },
     setLink: function(scope) {
@@ -9,7 +9,7 @@ angular.module("Prometheus.services").factory('WidgetLinkHelper', ["$http", "Inp
         return;
       }
       this.promise.then(function(payload) {
-        scope.widgetLink = location.origin + "/w/" + payload.data.id;
+        scope.widgetLink = location.origin + '<%= Rails.configuration.path_prefix %>w/' + payload.data.id;
       });
       this.promise = null;
       return this;

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -48,7 +48,7 @@ class DashboardsController < ApplicationController
     @dashboard = Dashboard.new_permalink(dashboard_params)
     if @dashboard.save
       payload = {
-        url: "/permalink/" + SlugMaker.slug("#{@dashboard.id} #{@dashboard.slug}")
+        url: Rails.configuration.path_prefix + "permalink/" + SlugMaker.slug("#{@dashboard.id} #{@dashboard.slug}")
       }
       render json: payload, status: :created
     else

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-	  <%= link_to('PromDash', root_path, class: 'navbar-brand' ) %>
+          <%= link_to('PromDash', root_path, class: 'navbar-brand' ) %>
         </div>
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav">

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,18 @@ module PrometheusDashboard
     # Required for working dashboard JSON PUTs.
     # See http://stackoverflow.com/a/25428800/915941.
     config.action_dispatch.perform_deep_munge = false
+
+    config.path_prefix = ENV['PROMDASH_PATH_PREFIX'] || '/'
+    unless config.path_prefix.start_with?('/')
+      config.path_prefix = '/' + config.path_prefix
+    end
+    unless config.path_prefix.end_with?('/')
+      config.path_prefix = config.path_prefix + '/'
+    end
+
+    unless config.path_prefix == '/'
+      # To prevent a double slash like /prefix//assets we'll cut off the last bit of path_prefix
+      config.assets.prefix = config.path_prefix[0..-2] + config.assets.prefix
+    end
   end
 end

--- a/config/initializers/entypo.rb
+++ b/config/initializers/entypo.rb
@@ -1,0 +1,2 @@
+# We'll reregister the charmap in routes.rb to support path prefixes
+Entypo.charmap = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,24 +1,34 @@
 PrometheusDashboard::Application.routes.draw do
-  mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
 
-  if Rails.env.test?
-    require_relative '../spec/support/fauxmetheus/fauxmetheus'
-    get '/api/:path' => FauxMetheus
+  if Rails.configuration.path_prefix != '/'
+    get '/', to: redirect(Rails.configuration.path_prefix)
   end
 
-  resources :dashboards, except: :index
-  resources :servers
-  resources :directories
+  scope Rails.configuration.path_prefix do
 
-  get '/annotations', to: 'dashboards#annotations'
-  get '/dashboards/:id/clone', to: 'dashboards#clone', as: :clone_dashboard
-  get '/dashboards/:id/widgets', to: 'dashboards#widgets'
-  get '/w/:slug', to: 'single_widget#show', as: 'single_widget'
-  post '/w', to: 'single_widget#create'
-  get '/permalink/:id', to: 'dashboards#show'
-  post '/permalink', to: 'dashboards#permalink'
-  get '/embed/:slug', to: 'embed#show'
-  get '/:slug', to: 'dashboards#show', as: 'dashboard_slug'
-  match '/:slug', to: 'dashboards#update', as: 'dashboard_slug_put', via: [:put, :patch]
-  root 'directories#index'
+    mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
+
+    if Rails.env.test?
+      require_relative '../spec/support/fauxmetheus/fauxmetheus'
+      get '/api/:path' => FauxMetheus
+    end
+
+    resources :dashboards, except: :index
+    resources :servers
+    resources :directories
+
+    get '/annotations', to: 'dashboards#annotations'
+    get '/dashboards/:id/clone', to: 'dashboards#clone', as: :clone_dashboard
+    get '/dashboards/:id/widgets', to: 'dashboards#widgets'
+    get '/w/:slug', to: 'single_widget#show', as: 'single_widget'
+    post '/w', to: 'single_widget#create'
+    get '/permalink/:id', to: 'dashboards#show'
+    post '/permalink', to: 'dashboards#permalink'
+    get '/embed/:slug', to: 'embed#show'
+    get '/:slug', to: 'dashboards#show', as: 'dashboard_slug'
+    match '/:slug', to: 'dashboards#update', as: 'dashboard_slug_put', via: [:put, :patch]
+    get '/_entypo/charmap', to: 'entypo/charmap#index'
+    root 'directories#index'
+
+  end
 end


### PR DESCRIPTION
Same as https://github.com/prometheus/prometheus/pull/614 but then for PromDash.

This pull request should be closely reviewed, I have no experience with Rails. All feedback greatly appreciated.

According to `rake routes` everything is covered. I am currently running PromDash on this code behind a proxy without any issues.

* I had to delete the `tmp/` folder to flush some cached files. I have no idea if this is always required.
* `graph_template.html.erb` and `pie_template.html.erb` contain an `<a href="/{{dashboard.slug}}">` but I have no idea how those tags are used