### PR TITLE
Vars Interpolation in Servers

### DIFF
--- a/app/assets/javascripts/angular/controllers/pie_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/pie_ctrl.js
@@ -17,7 +17,7 @@ angular.module("Prometheus.controllers").controller('PieCtrl',
       return;
     }
     $scope.requestInFlight = true;
-    $http.get(URLGenerator(server.url, '/api/query'), {
+    $http.get(URLGenerator(server.url, '/api/query', $scope.vars), {
       params: {
         expr: exp.expression
       }

--- a/app/assets/javascripts/angular/resources/shared_graph_behavior.js
+++ b/app/assets/javascripts/angular/resources/shared_graph_behavior.js
@@ -60,6 +60,22 @@ angular.module("Prometheus.services").factory("SharedGraphBehavior", ["$http", "
       }
     }
 
+    function addVarsFromServerInterpolations(servers) {
+      var singleInterpolation = /{{\s?(\w+)\s?}}/g;
+      for (var i = 0; i < servers.length; i++) {
+        while (match = singleInterpolation.exec(servers[i].url)) {
+          var_name = match[1]
+          if (!(var_name in $scope.globalConfig.vars)) {
+            console.log("Found " + var_name + " in " + servers[i].url)
+            $scope.globalConfig.vars[var_name] = ''  // no default value
+          }
+        }
+      }
+    }
+
+    $scope.servers = servers;
+    addVarsFromServerInterpolations(servers)
+
     $scope.$watch(function() {
       return $location.url();
     }, function() {
@@ -67,7 +83,7 @@ angular.module("Prometheus.services").factory("SharedGraphBehavior", ["$http", "
     });
 
     $scope.globalConfig.tags = $scope.globalConfig.tags || [];
-    $scope.servers = servers;
+
 
     $scope.sortableOptions = {
       handle: ".widget_title",

--- a/app/assets/javascripts/angular/services/graph_refresher.js
+++ b/app/assets/javascripts/angular/services/graph_refresher.js
@@ -10,7 +10,7 @@ angular.module("Prometheus.services").factory('GraphRefresher',
   return function($scope) {
     function loadGraphData(idx, expression, server, expressionID, endTime, rangeSeconds, step) {
       var deferred = $q.defer();
-      $http.get(URLGenerator(server.url, '/api/query_range'), {
+      $http.get(URLGenerator(server.url, '/api/query_range', $scope.vars), {
         params: {
           expr: expression,
           range: rangeSeconds,

--- a/app/assets/javascripts/angular/services/metric_names_querier.js
+++ b/app/assets/javascripts/angular/services/metric_names_querier.js
@@ -6,7 +6,7 @@ angular.module("Prometheus.services").factory('MetricNamesQuerier', ["$http", "U
       scope.metricNames = metricNamesCache[serverID];
       return;
     }
-    $http.get(URLGenerator(serverURL, '/api/metrics')).success(function(metricNames) {
+    $http.get(URLGenerator(serverURL, '/api/metrics', scope.vars)).success(function(metricNames) {
       metricNamesCache[serverID] = metricNames;
       scope.metricNames = metricNames;
       return;

--- a/app/assets/javascripts/angular/services/url_generator.js
+++ b/app/assets/javascripts/angular/services/url_generator.js
@@ -1,5 +1,7 @@
-angular.module("Prometheus.services").factory('URLGenerator', [function() {
-  return function(url, path) {
+angular.module("Prometheus.services").factory('URLGenerator', ["VariableInterpolator", function
+(VariableInterpolator) {
+  return function(url, path, vars) {
+    url = VariableInterpolator(url, vars)
     var a = document.createElement('a');
     a.href = url;
     a.pathname = a.pathname.replace(/\/?$/, path);

--- a/spec/javascripts/angular/services/url_generator_spec.js
+++ b/spec/javascripts/angular/services/url_generator_spec.js
@@ -8,7 +8,7 @@ describe('URLGenerator', function() {
   it('allows urls with custom paths, no trailing slash', function() {
     ['http://promdash.server.com/prometheus', 'http://promdash.com'].forEach(function(s) {
       ['/api/query_range', '/api/query', '/api/metrics', '/arbitrary/endpoint'].forEach(function(ep) {
-        var url = urlGenerator(s, ep);
+        var url = urlGenerator(s, ep, {});
         expect(url).toEqual(s + ep);
       });
     });
@@ -17,7 +17,7 @@ describe('URLGenerator', function() {
   it('allows urls with custom paths, with trailing slash', function() {
     ['http://promdash.server.com/prometheus/', 'http://promdash.com/'].forEach(function(s) {
       ['/api/query_range', '/api/query', '/api/metrics', '/arbitrary/endpoint'].forEach(function(ep) {
-        var url = urlGenerator(s, ep);
+        var url = urlGenerator(s, ep, {});
         expect(url).toEqual(s.substring(0, s.length - 1) + ep);
       });
     });


### PR DESCRIPTION
So this is a first pass on https://github.com/prometheus/promdash/issues/180. I'm quite foreign to AngularJS and Ruby, so I'm not sure if this is the right approach.

Everything seems to work:
 * specifying `{{my_var}}` in a server URL will make it be interpolated from template `scope.vars`
 * if template vars already don't specify the variable, it will be extracted out of server definitions and added with an empty value

There is one problem now:
Listing and viewing servers that contain interpolation variables causes them to be ignored in HTML. Editing in HTML and viewing in JSON works, and the data is in the DB. I presume (wild guess here) the problem may be that AngularJS interprets `{{my_var}}` as a directive and tries to bind it, and it defaults to empty. I don't know how to work around it though. Is there a way to make AngularJS ignore directives in a given node?