### PR TITLE
Change Gemfile to install sqlite outside of development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,16 +6,12 @@ gem 'rails', '4.1.7'
 # Allow people to ignore the database provider they don't need by doing bundle install --without mysql
 gem 'mysql2', group: 'mysql'
 gem 'pg', group: 'postgresql'
+gem 'sqlite3', group: 'sqlite3'
 
 gem 'active_model_serializers'
 
 group :production do
   gem 'thin'
-end
-
-group :development do
-  # Use sqlite3 as the database for Active Record
-  gem 'sqlite3'
 end
 
 group :test, :development do


### PR DESCRIPTION
I was trying the official docker image with a sqlite database backend to play around, and got this error:

```
Specified 'sqlite3' for database adapter, but the gem is not loaded. Add `gem 'sqlite3'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord). (Gem::LoadError)
```

So I moved the sqlite3 gem to the general pool


@grobie @juliusv 