### PR TITLE
Don't add frame if user cancels.

### DIFF
--- a/app/assets/javascripts/angular/controllers/dashboard_ctrl.js.erb
+++ b/app/assets/javascripts/angular/controllers/dashboard_ctrl.js.erb
@@ -130,13 +130,15 @@ angular.module("Prometheus.controllers")
 
   $scope.addFrame = function() {
     var url = prompt("Please enter the URL for the frame to display", "http://");
-    $scope.widgets.push({
-      type: "frame",
-      title: "",
-      range: $scope.globalConfig.range,
-      endTime: $scope.globalConfig.endTime,
-      url: url
-    });
+    if (url) {
+      $scope.widgets.push({
+        type: "frame",
+        title: "",
+        range: $scope.globalConfig.range,
+        endTime: $scope.globalConfig.endTime,
+        url: url
+      });
+    }
   };
 
   $scope.addGraph = function() {

--- a/spec/features/graph_spec.rb
+++ b/spec/features/graph_spec.rb
@@ -60,16 +60,23 @@ feature "Dashboard#show", js: true do
           open_tab 'Remove graph'
           click_button 'Delete'
           click_button 'Add Frame'
-          accept_alert
-          open_tab 'Remove frame'
+        end
+
+        it "should allow canceling on frame creation" do
+          dismiss_alert
+          expect(all('.widget_title').count).to eq 0
         end
 
         it "should remove frames" do
+          accept_alert
+          open_tab 'Remove frame'
           click_button 'Delete'
           expect(all('.widget_title').count).to eq 0
         end
 
         it "should cancel" do
+          accept_alert
+          open_tab 'Remove frame'
           click_button 'Cancel'
           expect(all('.widget_title').count).to eq 1
         end

--- a/spec/support/helper_functions.rb
+++ b/spec/support/helper_functions.rb
@@ -2,6 +2,10 @@ def accept_alert
   page.driver.browser.switch_to.alert.accept
 end
 
+def dismiss_alert
+  page.driver.browser.switch_to.alert.dismiss
+end
+
 def open_tab tab_name
   find(".widget_title").hover
   find("[tooltip='#{tab_name}']").click


### PR DESCRIPTION
Previously, canceling would not abort adding a frame, which would break
the UI.

fixes #388 