### PR TITLE
Broken frame widgets now can be modified and fixed.

### DIFF
--- a/app/assets/javascripts/angular/directives/frame.js.erb
+++ b/app/assets/javascripts/angular/directives/frame.js.erb
@@ -33,9 +33,14 @@ angular.module("Prometheus.directives").directive('inlineFrame', ["$sce",
       // http://khaidoan.wikidot.com/iframe-and-browser-history
       scope.refreshFrame = function() {
         var url = VariableInterpolator(scope.frame.url, scope.vars);
-        var trustedURL = $sce.trustAsResourceUrl(buildFrameURL(url));
+        var parser = buildParser(url);
+        var trustedURL = $sce.trustAsResourceUrl(parser.stringify());
         var frame = element.find('.frame_container');
         frame.height(frameHeight());
+        if (parser.error) {
+          frame.html('<div>Error: ' + parser.error + '. Please check your frame URL.</div>');
+          return;
+        }
         frame.html('<iframe src="'+ trustedURL +'" class="frame_iframe" marginwidth="0" scrolling="no"></iframe>');
       };
 
@@ -47,14 +52,14 @@ angular.module("Prometheus.directives").directive('inlineFrame', ["$sce",
         scope.$on(m, scope.refreshFrame);
       });
 
-      function buildFrameURL(url) {
+      function buildParser(url) {
         var parser = URLParser(url, {ignoreHash: scope.frame.graphite});
 
         if (scope.frame.graphite) {
           setGraphiteParams(parser);
         }
 
-        return parser.stringify();
+        return parser;
       }
 
       function setGraphiteParams(parser) {

--- a/app/assets/javascripts/angular/services/url_config.js
+++ b/app/assets/javascripts/angular/services/url_config.js
@@ -93,7 +93,28 @@ angular.module("Prometheus.services").factory('URLParser', function() {
     removeHashParam: function (key) { delete this.hash[key]; }
   };
 
+  function BrokenURL(brokenURL, error) {
+    this.brokenURL = brokenURL;
+    this.error = error;
+  }
+
+  BrokenURL.prototype = {
+    stringify: function() {
+      return this.brokenURL;
+    },
+    getQueryParams: function () { return []; },
+    setQueryParam: function () {},
+    removeQueryParam: function () {},
+    getHashParams: function () { return []; },
+    setHashParam: function () {},
+    removeHashParam: function () {}
+  };
+
   return function (url, options) {
-    return new URLRepresentation(url, options);
+    try {
+      return new URLRepresentation(url, options);
+    } catch (e) {
+      return new BrokenURL(url, e.message);
+    }
   };
 });

--- a/app/assets/javascripts/angular/services/url_generator.js
+++ b/app/assets/javascripts/angular/services/url_generator.js
@@ -1,5 +1,4 @@
-angular.module("Prometheus.services").factory('URLGenerator', ["VariableInterpolator", function
-(VariableInterpolator) {
+angular.module("Prometheus.services").factory('URLGenerator', ["VariableInterpolator", function(VariableInterpolator) {
   return function(url, path, vars) {
     url = VariableInterpolator(url, vars);
     var a = document.createElement('a');

--- a/spec/features/frame/frame_spec.rb
+++ b/spec/features/frame/frame_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+feature "Dashboard#show", js: true do
+  describe "frame widgets" do
+    before(:each) do
+      @server = Server.create! name: "prometheus", url: "http://localhost:#{Capybara.server_port}/"
+      @dashboard = FactoryGirl.create(:dashboard)
+      FactoryGirl.create :directory, dashboards: [ @dashboard ]
+      visit dashboard_slug_path @dashboard.slug
+      # Remove the currently existing graph.
+      open_tab 'Remove graph'
+      click_button 'Delete'
+    end
+
+    describe "with malformed URIs" do
+      let(:url) {'http://graphite.net/render?target=stacked(summarize(stats_counts.token.success.*,%2"1min"))'}
+      before :each do
+        click_button 'Add Frame'
+        fill_in_prompt url
+        within '.frame_container' do
+          expect(page).to have_content "Error"
+        end
+      end
+
+      it "can still be interacted with" do
+        open_tab 'Frame Source'
+        frame_element = model_element('frame.url')
+        expect(frame_element.value).to eq(url)
+        frame_element.set "http://google.com"
+        within '.frame_container' do
+          expect(page).to have_no_content "Error"
+        end
+      end
+
+      it "can still be deleted" do
+        open_tab 'Remove frame'
+        click_button 'Delete'
+        expect(all('.widget_title').count).to eq 0
+      end
+    end
+  end
+end

--- a/spec/support/helper_functions.rb
+++ b/spec/support/helper_functions.rb
@@ -6,6 +6,11 @@ def dismiss_alert
   page.driver.browser.switch_to.alert.dismiss
 end
 
+def fill_in_prompt text
+  page.driver.browser.switch_to.alert.send_keys text
+  accept_alert
+end
+
 def open_tab tab_name
   find(".widget_title").hover
   find("[tooltip='#{tab_name}']").click


### PR DESCRIPTION
Previously, broken frame widgets were totally borked and could not be
removed or modified. This allows the user to modify frame widgets if
they break because of an error parsing the frame url.

@juliusv 