### PR TITLE
Only set logarithm-based graph min if logarithm scales are present.

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -84,18 +84,28 @@ angular.module("Prometheus.directives").directive('graphChart', [
 
         var series = RickshawDataTransformer(graphData, axisIDByExprID);
 
-        var seriesYLimitFn = calculateBound(series);
-        var yMinForLog = seriesYLimitFn(Math.min);
-        var yMin = yMinForLog > 0 ? 0 : yMinForLog;
-        var yMax = seriesYLimitFn(Math.max);
+        var yMinForGraph;
+        var hasLog;
+        scope.graphSettings.axes.forEach(function(a) {
+          if (a.scale === "log" ) {
+            hasLog = true;
+          }
+        });
 
-        var yMinForGraph = yMin;
-        // The range on the y-axis is way too large if both yMin and yMax are
-        // negative. Setting yMin to 0 fixes this.
-        if (yMinForLog > 0) {
-          yMinForGraph = 0;
-        } else if (yMin < 0 && yMax < 0) {
-          yMinForGraph = 0;
+        if (hasLog) {
+          var seriesYLimitFn = calculateBound(series);
+          var yMinForLog = seriesYLimitFn(Math.min);
+          var yMin = yMinForLog > 0 ? 0 : yMinForLog;
+          var yMax = seriesYLimitFn(Math.max);
+
+          yMinForGraph = yMin;
+          // The range on the y-axis is way too large if both yMin and yMax are
+          // negative. Setting yMin to 0 fixes this.
+          if (yMinForLog > 0) {
+            yMinForGraph = 0;
+          } else if (yMin < 0 && yMax < 0) {
+            yMinForGraph = 0;
+          }
         }
 
         // Set scale in yScales based on max/min of all series on that axis.


### PR DESCRIPTION
Setting the scale when there are series with both positive and negative
values according to a logarithmic minimum causes the minimum of the
graph to drop way out of control. This is only set when a logarithmic
scale exists.