### PR TITLE
Smaller size docker image refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,26 @@
-FROM       ruby:2.1.5-onbuild
+FROM       alpine:3.1
 MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
-ENV        RAILS_ENV production
-
+EXPOSE     3000
 ENTRYPOINT [ "./run" ]
 CMD        [ "./bin/thin", "start" ]
-RUN        cp config/database.yml.example config/database.yml && \
-           bundle install --deployment --binstubs --without="development test migration" && \
-           bundle exec rake assets:precompile
-RUN        printf '#!/bin/sh\n \
-           [ -z "$DATABASE_URL" ] && { echo "DATABASE_URL not set"; exit 1; }\n \
-           export DB_HOST=$(echo $DB_PORT_3306_TCP|sed "s|^tcp://||")\n \
-           export DATABASE_URL=$(echo "$DATABASE_URL" | sed "s/\[HOST\]/$DB_HOST/")\n \
-           exec $@\n' > run && chmod a+x run
-EXPOSE     3000
+
+ENV     RAILS_ENV production
+WORKDIR /usr/src/app
+COPY    . /usr/src/app
+
+RUN apk add --update -t build-deps openssl ca-certificates make gcc musl-dev libgcc g++ mysql-dev postgresql-dev sqlite-dev \
+    && apk add ruby ruby-dev nodejs tzdata \
+    && echo 'gem: --no-rdoc --no-ri' >> "$HOME/.gemrc" \
+    && cp config/database.yml.example config/database.yml \
+    && bin/env gem install bundler --bindir bin/ --no-document \
+    && bin/env bin/bundle install --deployment --binstubs --without="development test migration" \
+    && rm -rf public/assets/* \
+    && bin/env bin/bundle exec rake assets:precompile \
+    && apk del --purge build-deps \
+    && apk add mysql-libs sqlite-libs libpq \
+    && rm -rf /var/cache/apk/* \
+    && printf '#!/bin/sh\n \
+       [ -z "$DATABASE_URL" ] && { echo "DATABASE_URL not set"; exit 1; }\n \
+       export DB_HOST=$(echo $DB_PORT_3306_TCP|sed "s|^tcp://||")\n \
+       export DATABASE_URL=$(echo "$DATABASE_URL" | sed "s/\[HOST\]/$DB_HOST/")\n \
+       exec $@\n' > run && chmod a+x run

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following is a quick-start example for running PromDash with a file-based lo
 
 First, create the SQLite3 database in a shared local Docker volume on the host:
 
-    docker run -p 3000:3000 -v /tmp/prom:/tmp/prom -e DATABASE_URL=sqlite3:/tmp/prom/file.sqlite3 prom/promdash ./bin/rake db:migrate
+    docker run -v /tmp/prom:/tmp/prom -e DATABASE_URL=sqlite3:/tmp/prom/file.sqlite3 prom/promdash ./bin/rake db:migrate
 
 Now, we launch Prometheus with the database we've just created:
 


### PR DESCRIPTION
Like the prometheus one, here is my small size docker image refactoring.

![promdash_optimized_docker_image](https://cloud.githubusercontent.com/assets/1931038/7879007/62b417e4-05ec-11e5-84db-d3a7b167e05d.png)

I got some hard times, ruby projects have so much dependencies :p

If some people could test it before merging this PR, I would really appreciate it. Just to be sure there is no regressions. I may have missed something.

@discordianfish @juliusv 