### PR TITLE
fix hostname filter

### DIFF
--- a/app/assets/javascripts/angular/filters/filters.js
+++ b/app/assets/javascripts/angular/filters/filters.js
@@ -20,9 +20,9 @@ angular.module("Prometheus.filters").filter('hostnameFqdn', function() {
 
 angular.module("Prometheus.filters").filter('hostname', function() {
   return function(input) {
-    var a = document.createElement("a");
-    a.href = input;
-    return a.host.split(".", 1)[0];
+    var re = /^([^:\/?#]+:\/\/)?([^\/?#]*)?/;
+    var match = input.match(re);
+    return match ? match[2] : '';
   };
 });
 

--- a/spec/javascripts/angular/filters/filters_spec.js
+++ b/spec/javascripts/angular/filters/filters_spec.js
@@ -19,9 +19,20 @@ describe('filters', function() {
     expect(host('http://sub-domain.domain.com/path?search')).toEqual('sub-domain.domain.com');
   });
 
-  it('host', function() {
-    var host = $filter('hostname');
-    expect(host('http://domain.com/path?search')).toEqual('domain');
+  describe('host', function() {
+    it('with protocol', function() {
+      var host = $filter('hostname');
+      expect(host('http://domain.com:9090/path?search')).toEqual('domain.com:9090');
+      expect(host('http://domain.com/path?search')).toEqual('domain.com');
+      expect(host('ws://domain:9000/path?search')).toEqual('domain:9000');
+    });
+
+    it('without protocol', function() {
+      var host = $filter('hostname');
+      expect(host('domain.local:9090/path?search')).toEqual('domain.local:9090');
+      expect(host('domain.local/path?search')).toEqual('domain.local');
+      expect(host('domain:9000/path?search')).toEqual('domain:9000');
+    });
   });
 
   describe('regex', function() {
@@ -31,12 +42,13 @@ describe('filters', function() {
     });
 
     it('exact match', function() {
-      expect(regex('important-data.generic-data', '\.generic-data', '')).toEqual('important-data');
+      expect(regex('important-data.generic-data', '.generic-data', '')).toEqual('important-data');
     });
 
     it('special characters', function() {
       expect(regex('important-data32398', '\\d', '')).toEqual('important-data');
       expect(regex('important-data32398', '[a-zA-Z-]', '')).toEqual('32398');
+      expect(regex('some_random_stuff_SPECIAL', 'some_random_stuff_', '')).toEqual('SPECIAL');
     });
   });
 });


### PR DESCRIPTION
hostname filter was broken if a scheme was not present.

uses a  modified version of the regex found at
http://www.ietf.org/rfc/rfc3986.txt appendix B

fixes #415

@grobie @juliusv 