### PR TITLE
Turn on html5 mode.

### DIFF
--- a/app/assets/javascripts/angular/app.js
+++ b/app/assets/javascripts/angular/app.js
@@ -15,4 +15,6 @@ angular.module("Prometheus",
   $rootScope.alert = function(thing) {
     alert(thing);
   };
+}]).config(['$locationProvider', function($locationProvider) {
+  $locationProvider.html5Mode(true);
 }]);

--- a/app/assets/javascripts/angular/app.js
+++ b/app/assets/javascripts/angular/app.js
@@ -6,7 +6,7 @@ angular.module("Prometheus.filters", []);
 
 angular.module("Prometheus",
   ["ui.sortable", "ui.bootstrap", "ui.slider", "Prometheus.controllers", "Prometheus.directives", "Prometheus.resources", "Prometheus.services", "Prometheus.filters"])
-.run(['$rootScope', function($rootScope) {
+.run(['$rootScope', '$location', function($rootScope, $location) {
   // adds some basic utilities to the $rootScope for debugging purposes
   $rootScope.log = function(thing) {
     console.log(thing);
@@ -15,6 +15,10 @@ angular.module("Prometheus",
   $rootScope.alert = function(thing) {
     alert(thing);
   };
+
+  if ($location.hash()[0] === "?") {
+    $location.url($location.path() + $location.hash());
+  }
 }]).config(['$locationProvider', function($locationProvider) {
   $locationProvider.html5Mode(true);
 }]);


### PR DESCRIPTION
A bug was found wherein a user was unable to render a promdash dashboard
within a frame widget if that dashboard relied on query string
parameters.

Without html5 mode engaged, the query string was only interpreted by the
angular code if it was preceded by a hash (`#`), e.g.:

`http://promdash.com/my-dashboard/#/?some=components&and=others`

However, the URL escaping code executed on frame URLs escapes all code
after the final hash (`#`), would would escape the `?` and break the
dashboard rendered in the frame.

A work-around for now is to add another `#` and some garbage behind it:

`http://promdash.com/my-dashboard/#/?some=components&and=others#garbageHash`

With html5 mode engaged, the above URL can be written as one is
accustomed now:

`http://promdash.com/my-dashboard?some=components&and=others`

__NOTE:__

This will break the variable parsing in current dashboards relying on the `/#?` format. Removing the `#` causes the variables to be parsed correctly.

@juliusv @grobie 