### PR TITLE
Add a cache for annotations requests.

### DIFF
--- a/app/assets/javascripts/angular/controllers/dashboard_ctrl.js.erb
+++ b/app/assets/javascripts/angular/controllers/dashboard_ctrl.js.erb
@@ -10,6 +10,7 @@ angular.module("Prometheus.controllers")
             "InputHighlighter",
             "ModalService",
             "Palettes",
+            "AnnotationRefresher",
             function($scope,
                      $window,
                      $http,
@@ -20,7 +21,8 @@ angular.module("Prometheus.controllers")
                      SharedGraphBehavior,
                      InputHighlighter,
                      ModalService,
-                     Palettes) {
+                     Palettes,
+                     AnnotationRefresher) {
 
   $window.onresize = function() {
     $scope.$broadcast('redrawGraphs');
@@ -202,6 +204,7 @@ angular.module("Prometheus.controllers")
         w.tags = $scope.globalConfig.tags;
       }
     });
+    AnnotationRefresher.clearCache($scope.globalConfig.range, $scope.globalConfig.endTime);
   }, true);
 
   if ($scope.widgets.length === 0) {

--- a/app/assets/javascripts/angular/controllers/graph_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/graph_ctrl.js
@@ -6,15 +6,13 @@ angular.module("Prometheus.controllers").controller('GraphCtrl',
                                                       "YAxisUtilities",
                                                       "SharedWidgetSetup",
                                                       "Palettes",
-                                                      "AnnotationRefresher",
                                                       function($scope,
                                                                $http,
                                                                $timeout,
                                                                GraphRefresher,
                                                                YAxisUtilities,
                                                                SharedWidgetSetup,
-                                                               Palettes,
-                                                               AnnotationRefresher) {
+                                                               Palettes) {
   SharedWidgetSetup($scope);
 
   // TODO: Set these on graph creation so we don't have to keep doing these
@@ -135,7 +133,6 @@ angular.module("Prometheus.controllers").controller('GraphCtrl',
       debounce = $timeout(function() {
         refreshFn($scope.graph.endTime, $scope.graph.range, step).then(function(data) {
           scope.$broadcast('redrawGraphs', data);
-          AnnotationRefresher(scope.graph, scope);
         });
       }, timeout);
     };
@@ -154,8 +151,6 @@ angular.module("Prometheus.controllers").controller('GraphCtrl',
   $scope.$watch('graph.resolution', function() {
     $scope.refreshGraph();
   });
-
-  $scope.refreshGraph();
 
   if (location.pathname.match(/^\/w\//)) { // On a widget page.
     $scope.widgetPage = true;

--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -6,6 +6,7 @@ angular.module("Prometheus.directives").directive('graphChart', [
     "RickshawDataTransformer",
     "GraphiteDataTransformer",
     "YAxisUtilities",
+    "AnnotationRefresher",
     "HTMLEscaper",
     function(
       $location,
@@ -15,6 +16,7 @@ angular.module("Prometheus.directives").directive('graphChart', [
       RickshawDataTransformer,
       GraphiteDataTransformer,
       YAxisUtilities,
+      AnnotationRefresher,
       HTMLEscaper) {
   return {
     scope: {
@@ -48,7 +50,7 @@ angular.module("Prometheus.directives").directive('graphChart', [
         });
       }
 
-      function annotate() {
+      function annotate(annotationData) {
         if (!rsGraph || !annotationData.length) {
           return;
         }
@@ -311,6 +313,9 @@ angular.module("Prometheus.directives").directive('graphChart', [
         rsGraph.series.legend = legend;
         rsGraph.render();
 
+        AnnotationRefresher.refresh(scope.graphSettings.tags, scope.graphSettings.range, scope.graphSettings.endTime, scope.vars)
+          .result(scope.graphSettings.range, scope.graphSettings.endTime, annotate);
+
         new Rickshaw.Graph.DragZoom({
           graph: rsGraph,
           opacity: 0.5,
@@ -472,10 +477,6 @@ angular.module("Prometheus.directives").directive('graphChart', [
       scope.$watch('graphSettings.showLegend', redrawGraph);
       scope.$watch('graphSettings.axes', redrawGraph, true);
       scope.$watch('graphData', redrawGraph, true);
-      scope.$on('annotateGraph', function(e, data) {
-        annotationData = data;
-        annotate();
-      });
       scope.$on('redrawGraphs', function(e, data) {
         if (data !== undefined) {
           graphData = data;

--- a/app/assets/javascripts/angular/resources/shared_graph_behavior.js
+++ b/app/assets/javascripts/angular/resources/shared_graph_behavior.js
@@ -151,6 +151,8 @@ angular.module("Prometheus.services").factory("SharedGraphBehavior", ["$http", "
       $scope.$broadcast('refreshDashboard');
     };
 
+    $scope.refreshDashboard();
+
     $scope.redrawGraphs = function() {
       $scope.$broadcast('redrawGraphs');
     };

--- a/app/assets/javascripts/angular/services/annotation_refresher.js.erb
+++ b/app/assets/javascripts/angular/services/annotation_refresher.js.erb
@@ -1,31 +1,66 @@
-angular.module("Prometheus.services").factory('AnnotationRefresher', ["$http", "VariableInterpolator", function($http, VariableInterpolator) {
-  return function(graph, scope) {
-    var tags = graph.tags.map(function(e) {
-      if (e.name) {
-        var n = VariableInterpolator(e.name, scope.vars);
-        return n.split(",").map(function(s) { return s.trim(); });
-      } else {
-        return "";
-      }
-    });
-    if (tags.length) {
-      var range = Prometheus.Graph.parseDuration(graph.range);
-      var until = Math.floor(graph.endTime || Date.now()) / 1000;
-
-      tags.forEach(function(t) {
-        $http.get('<%= Rails.configuration.path_prefix %>annotations', {
-          params: {
-            'tags[]': t,
-            until: until,
-            range: range
-          }
-        })
-        .then(function(payload) {
-          scope.$broadcast('annotateGraph', payload.data.posts);
-        }, function(response) {
-          scope.errorMessages.push("Error " + response.status + ": Error occurred fetching annotations.");
-        });
+angular.module("Prometheus.services").factory('AnnotationRefresher', ["$http", "$q", "$timeout", "VariableInterpolator", function($http, $q, $timeout, VariableInterpolator) {
+  var MINUTE = 1000*60;
+  var promises = {};
+  var debounce;
+  function key(range, endTime) {
+    return "" + range + endTime;
+  }
+  return {
+    refresh: function(tags, range, endTime, vars) {
+      var tags = tags.map(function(e) {
+        if (e.name) {
+          var n = VariableInterpolator(e.name, vars);
+          return n.split(",").map(function(s) { return s.trim(); });
+        } else {
+          return "";
+        }
       });
+
+      var k = key(range, endTime);
+
+      if (tags.length) {
+        var r = Prometheus.Graph.parseDuration(range);
+        var until = Math.floor(endTime || Date.now()) / 1000;
+
+        if (!promises[k]) {
+
+          // Delete the cached annotations after 1 minute.
+          var clear = function(key) {
+            return function() { promises[key] = undefined; };
+          }(k);
+          $timeout(clear, 1*MINUTE);
+
+          promises[k] = tags.map(function(t) {
+            return $http.get(dashboardURL + 'annotations', {
+              params: {
+                'tags[]': t,
+                until: until,
+                range: r
+              }
+            }).then(function(payload) {
+              return payload.data.posts;
+            }, function(response) {
+              return [];
+            });
+          });
+        }
+      } else {
+        promises[k] = undefined;
+      }
+
+      return this;
+    },
+    result: function(range, endTime, fn) {
+      var p = promises[key(range, endTime)];
+
+      if (p) {
+        return $q.all(p).then(function(posts) {
+          return $.map(posts, function(n) { return n; });
+        }).then(fn);
+      }
+    },
+    clearCache: function(range, endTime) {
+      promises[key(range, endTime)] = undefined;
     }
   };
 }]);

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -2,6 +2,7 @@
   dashboardData = <%= @dashboard.dashboard_json ? @dashboard.dashboard_json.html_safe : '{}' %>;
   dashboardName = "<%= @dashboard.name %>";
   directoryName = "<%= @directoryName %>";
+  dashboardURL = "<%= Rails.configuration.path_prefix %>";
   servers = <%= @servers.to_json.html_safe %>;
 </script>
 


### PR DESCRIPTION
Annotations requests are cached based on the dashboard's endTime and
range. If the dashboard has no set endTime (i.e. the annotation endTime
requested will keep changing), the cache for that range+endTime
combination is erased every 5 minutes.

Previously, annotations were requested every time for each individual dashboard.

@juliusv @grobie 