### PR TITLE
Fix the way that Bootstrap errors are rendered

### DIFF
--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |name, msg| %>
   <% if msg.is_a?(String) %>
-    <div ng-non-bindable class="alert alert-<%= name == :notice ? "success" : "error" %>">
+    <div ng-non-bindable class="alert alert-<%= name == "notice" ? "success" : "danger" %>">
       <a class="close" data-dismiss="alert">&#215;</a>
       <%= content_tag :div, msg, :id => "flash_#{name}" %>
     </div>


### PR DESCRIPTION
* In Bootstrap 3, the `-danger` suffix is used, not `-error`.
* The name parameter is a string, so the symbol comparison was failing.

:wave: to @juliusv and @stuartnelson3.