### PR TITLE
Create unique slug for dashboards

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,4 +205,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.10.1
+   1.10.4

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -16,7 +16,7 @@ class Dashboard < ActiveRecord::Base
   belongs_to :directory
   has_many :shortened_urls
 
-  validates :name, uniqueness: { case_sensitive: false }
+  validates :name, :slug, uniqueness: { case_sensitive: false }
   validates :name, :slug, presence: true
   validate :acceptable_slug
   validates :slug,
@@ -32,7 +32,7 @@ class Dashboard < ActiveRecord::Base
 
   def self.new_with_slug(params)
     dashboard = new(params)
-    dashboard.create_slug
+    dashboard.create_slug dashboard.name
     dashboard
   end
 
@@ -64,7 +64,10 @@ class Dashboard < ActiveRecord::Base
     (JSON.parse dashboard_json)['widgets']
   end
 
-  def create_slug
-    self.slug = SlugMaker.slug(name)
+  def create_slug name, n=nil
+    self.slug = SlugMaker.slug("#{name} #{n}")
+    if !valid? && errors[:slug].any?
+      create_slug name, n.to_i+1
+    end
   end
 end

--- a/db/migrate/20150814142427_dashboard_slug_uniqueness_constraint.rb
+++ b/db/migrate/20150814142427_dashboard_slug_uniqueness_constraint.rb
@@ -1,0 +1,5 @@
+class DashboardSlugUniquenessConstraint < ActiveRecord::Migration
+  def change
+    add_index :dashboards, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150601101059) do
+ActiveRecord::Schema.define(version: 20150814142427) do
 
   create_table "dashboards", force: true do |t|
     t.string   "name"
@@ -23,7 +23,8 @@ ActiveRecord::Schema.define(version: 20150601101059) do
     t.boolean  "permalink",      default: false
   end
 
-  add_index "dashboards", ["directory_id"], name: "index_dashboards_on_directory_id", using: :btree
+  add_index "dashboards", ["directory_id"], name: "index_dashboards_on_directory_id"
+  add_index "dashboards", ["slug"], name: "index_dashboards_on_slug", unique: true
 
   create_table "directories", force: true do |t|
     t.string   "name"
@@ -42,12 +43,12 @@ ActiveRecord::Schema.define(version: 20150601101059) do
   create_table "shortened_urls", force: true do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "encoded_url"
+    t.text     "encoded_url",   limit: 255
     t.datetime "last_accessed"
-    t.string   "checksum",      limit: 32, default: "", null: false
+    t.string   "checksum",      limit: 32,  default: "", null: false
     t.integer  "dashboard_id"
   end
 
-  add_index "shortened_urls", ["checksum"], name: "index_shortened_urls_on_checksum", unique: true, using: :btree
+  add_index "shortened_urls", ["checksum"], name: "index_shortened_urls_on_checksum", unique: true
 
 end

--- a/lib/slug_maker.rb
+++ b/lib/slug_maker.rb
@@ -1,5 +1,5 @@
 class SlugMaker
   def self.slug(name)
-    name.downcase.gsub(' ','-').gsub(/[^a-zA-Z0-9-]/, '')
+    name.downcase.strip.gsub(' ','-').gsub(/[^a-zA-Z0-9-]/, '')
   end
 end

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -16,11 +16,27 @@ describe Dashboard do
     end
     it "doesn't make blacklisted slug names" do
       d = Dashboard.new_with_slug(name: "dashboard")
-      expect(d).to_not be_valid
+      expect(d.slug).to eq('dashboard-1')
     end
     it "makes permalink dashboards" do
       d = Dashboard.new_permalink(name: "static dashboard")
       expect(d).to be_valid
+    end
+    it "creates unique slugs" do
+      d = Dashboard.new_with_slug(name: "dashboard-name-here")
+      d.save
+
+      # Verify that the first dashboard has been saved, necessitating a
+      # different slug for the following dashboard.
+      expect(d.persisted?).to eq(true)
+
+      c = Dashboard.new_with_slug(name: "dashboard-name here")
+
+      expect(c.slug).to eq('dashboard-name-here-1')
+      c.save
+
+      b = Dashboard.new_with_slug(name: "dashboard name here")
+      expect(b.slug).to eq('dashboard-name-here-2')
     end
   end
 


### PR DESCRIPTION
cases:
- dashboard slug already exists
- dashboard attempts to use blacklisted slug name

the behavior with blacklisted slugs was unexpected, but it has the result of letting users create dashboards with names that would normally have been blacklisted, but now are assigned a unique name.

@grobie 