### PR TITLE
Minor UI changes to the Dashboard

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -3,4 +3,5 @@ body { padding-top: 60px; }
 
 .panel-heading {
   font-weight: bold;
+  padding: 8px 10px 10px 10px;
 }

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -69,6 +69,7 @@ $light-secondary-background: #f0f0f0;
 .widget_wrapper {
   background-color: $light-secondary-background;
   border: none;
+  padding: 5px;
   width: 100%;
 }
 

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -39,10 +39,13 @@ $light-secondary-background: #f0f0f0;
 }
 
 .fullscreen {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
+  right: 0;
+  height: 100%;
+  overflow-y: scroll;
+  overflow-x: hidden;
   z-index: 1050; // Bootstrap's navbar is at 1030.
   background-color: #FFFFFF;
   padding: 3px;
@@ -67,8 +70,6 @@ $light-secondary-background: #f0f0f0;
 .widget_wrapper {
   background-color: $light-secondary-background;
   border: none;
-  padding: 5px;
-  position: relative;
   width: 100%;
 }
 

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -41,14 +41,13 @@ $light-secondary-background: #f0f0f0;
 .fullscreen {
   position: fixed;
   top: 0;
-  left: 0;
-  right: 0;
+  left: -6px;
+  right: -6px;
   height: 100%;
   overflow-y: scroll;
   overflow-x: hidden;
   z-index: 1050; // Bootstrap's navbar is at 1030.
   background-color: #FFFFFF;
-  padding: 3px;
 }
 
 .fullscreen_title_bump {

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -527,11 +527,11 @@ error-message {
   z-index: 1;
 }
 
-.graph_settings_image {
+.radio .graph_settings_image {
   background-repeat: no-repeat;
   background-size: 30px 17px;
-  background-position-y: -1px;
-  padding-left: 35px;
+  background-position-y: 1px;
+  padding-left: 58px;
 }
 
 hr {

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -639,6 +639,7 @@ hr {
 
 .expression_form {
   overflow: auto;
+  margin-bottom: 5px;
 }
 
 .expression_select {

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -12,10 +12,6 @@ $light-secondary-background: #f0f0f0;
   margin-bottom: 20px;
 }
 
-#global_controls {
-  margin-bottom: 8px;
-}
-
 .container-fluid {
   padding-right: 10px;
   padding-left: 10px;
@@ -587,7 +583,7 @@ hr {
 
 .global_grouping {
   float: left;
-  margin-right: 15px;
+  margin-right: 10px;
   position: relative;
   &:first-child {
     margin-left: 15px;

--- a/app/assets/templates/expression_template.html
+++ b/app/assets/templates/expression_template.html
@@ -1,7 +1,7 @@
 <div><b>Expression {{index + 1}}</b></div>
-<form class="form-inline expression_form">
-  <div class="form-group col-xs-4 pad-right expression_select" ng-class="{'col-xs-12': type !== 'graph' }">
-    <select class="form-control"
+<form class="expression_form">
+  <div class="col-xs-4 pad-right expression_select" ng-class="{'col-xs-12': type !== 'graph' }">
+    <select class="col-xs-4 form-control"
       ng-model="expr.serverID"
       ng-options="s.id as s.name for s in servers"
       ng-change="updateMetricNames()">
@@ -9,13 +9,13 @@
     </select>
   </div>
   <div ng-if="type === 'graph'">
-    <div class="form-group col-xs-4 expression_select pad-right">
-      <select class="form-control" ng-model="expr.axisID" ng-options="a.id as ('Axis ' + a.id) for a in axes">
+    <div class="col-xs-4 expression_select pad-right">
+      <select class="col-xs-4 form-control" ng-model="expr.axisID" ng-options="a.id as ('Axis ' + a.id) for a in axes">
         <option value="">- Select Axis -</option>
       </select>
     </div>
   </div>
-  <div ng-if="type === 'graph'" class="form-group col-xs-4 expression_select">
+  <div ng-if="type === 'graph'" class="col-xs-4 expression_select">
     <select class="form-control"
       ng-model="expr.legendID"
       ng-options="s.id as s.name for s in legendFormatStrings">

--- a/app/assets/templates/widget_time_options_template.html
+++ b/app/assets/templates/widget_time_options_template.html
@@ -5,45 +5,47 @@
      tooltip-append-to-body="true" tooltip="Close"></i>
   </div>
   <div class="panel-body">
-    <div class="col-lg-4">
-      <label>Relative range:</label>
-      <div class="input-group">
-        <span class="input-group-btn">
-          <button class="btn btn-default" ng-click="decreaseRange()" title="Decrease range">
-            <i class="icon-minus"></i>
-          </button>
-        </span>
-        <input type="text" class="form-control" ng-model="range" placeholder="Range">
-        <span class="input-group-btn">
-          <button class="btn btn-default" ng-click="increaseRange()" title="Increase range">
-            <i class="icon-plus"></i>
-          </button>
-        </span>
-      </div>
-    </div>
-
-    <div class="col-lg-7">
-      <label>End time:</label>
-      <div class="input-group">
-        <span class="input-group-btn">
-          <button class="btn btn-default" ng-click="decreaseEndTime()" title="Decrease end time">
-            <i class="icon-fb"></i>
-          </button>
-        </span>
-        <span class="until_container">
-          <input type="text" class="form-control" datetime-picker datetime="endTime" data-format="yyyy-MM-dd" placeholder="Until">
-          <span class="until_clear pointer"
-            ng-click="clearEndTime()"
-            ng-show="endTime"
-            tooltip-append-to-body="true" tooltip="Clear">
-            <i class="glyphicon glyphicon-remove"></i>
+    <div class="row">
+      <div class="col-lg-6">
+        <label>Relative range:</label>
+        <div class="input-group">
+          <span class="input-group-btn">
+            <button class="btn btn-default" ng-click="decreaseRange()" title="Decrease range">
+              <i class="icon-minus"></i>
+            </button>
           </span>
-        </span>
-        <span class="input-group-btn">
-          <button class="btn btn-default" ng-click="increaseEndTime()" title="Increase end time">
-            <i class="icon-ff"></i>
-          </button>
-        </span>
+          <input type="text" class="form-control" ng-model="range" placeholder="Range">
+          <span class="input-group-btn">
+            <button class="btn btn-default" ng-click="increaseRange()" title="Increase range">
+              <i class="icon-plus"></i>
+            </button>
+          </span>
+        </div>
+      </div>
+
+      <div class="col-lg-6">
+        <label>End time:</label>
+        <div class="input-group">
+          <span class="input-group-btn">
+            <button class="btn btn-default" ng-click="decreaseEndTime()" title="Decrease end time">
+              <i class="icon-fb"></i>
+            </button>
+          </span>
+          <span class="until_container">
+            <input type="text" class="form-control" datetime-picker datetime="endTime" data-format="yyyy-MM-dd" placeholder="Until">
+            <span class="until_clear pointer"
+              ng-click="clearEndTime()"
+              ng-show="endTime"
+              tooltip-append-to-body="true" tooltip="Clear">
+              <i class="glyphicon glyphicon-remove"></i>
+            </span>
+          </span>
+          <span class="input-group-btn">
+            <button class="btn btn-default" ng-click="increaseEndTime()" title="Increase end time">
+              <i class="icon-ff"></i>
+            </button>
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -16,7 +16,7 @@
       <button class="btn btn-default" ng-click="decreaseRange()" title="Decrease range">
         <i class="icon-minus"></i>
       </button>
-      <input type="text" class="form-control" ng-changed="setRange()" ng-model="globalConfig.range" placeholder="Range">
+      <input type="text" class="form-control" ng-changed="setRange()" ng-model="globalConfig.range" placeholder="Range"></input>
       <button class="btn btn-default" ng-click="increaseRange()" title="Increase range">
         <i class="icon-plus"></i>
       </button>
@@ -27,7 +27,7 @@
         <i class="icon-fb"></i>
       </button>
       <span class="until_container">
-        <input type="text" class="form-control" datetime-picker datetime="globalConfig.endTime" data-format="yyyy-MM-dd" placeholder="Until">
+        <input type="text" class="form-control" datetime-picker datetime="globalConfig.endTime" data-format="yyyy-MM-dd" placeholder="Until"></input>
         <span class="until_clear global pointer"
           ng-show="globalConfig.endTime"
           ng-click="globalConfig.endTime = null"

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -12,20 +12,27 @@
   </h1>
 
   <div id="global_controls">
-    <div class="global_grouping">
-      <button class="btn btn-default" ng-click="decreaseRange()" title="Decrease range">
-        <i class="icon-minus"></i>
-      </button>
+
+    <div class="input-group global_grouping global_time_input">
+      <span class="input-group-btn">
+        <button class="btn btn-default" ng-click="decreaseRange()" title="Decrease range">
+          <i class="icon-minus"></i>
+        </button>
+      </span>
       <input type="text" class="form-control" ng-changed="setRange()" ng-model="globalConfig.range" placeholder="Range"></input>
-      <button class="btn btn-default" ng-click="increaseRange()" title="Increase range">
-        <i class="icon-plus"></i>
-      </button>
+      <span class="input-group-btn">x
+        <button class="btn btn-default" ng-click="increaseRange()" title="Increase range">
+          <i class="icon-plus"></i>
+        </button>
+      </span>
     </div>
 
-    <div class="global_grouping">
-      <button class="btn btn-default" ng-click="decreaseEndTime()" title="Decrease end time">
-        <i class="icon-fb"></i>
-      </button>
+    <div class="input-group global_grouping global_date_input">
+      <span class="input-group-btn">
+        <button class="btn btn-default" ng-click="decreaseEndTime()" title="Decrease end time">
+          <i class="icon-fb"></i>
+        </button>
+      </span>
       <span class="until_container">
         <input type="text" class="form-control" datetime-picker datetime="globalConfig.endTime" data-format="yyyy-MM-dd" placeholder="Until"></input>
         <span class="until_clear global pointer"
@@ -35,9 +42,11 @@
           <i class="glyphicon glyphicon-remove"></i>
         </span>
       </span>
-      <button class="btn btn-default" ng-click="increaseEndTime()" title="Increase end time">
-        <i class="icon-ff"></i>
-      </button>
+      <span class="input-group-btn">x
+        <button class="btn btn-default" ng-click="increaseEndTime()" title="Increase end time">
+          <i class="icon-ff"></i>
+        </button>
+      </span>
     </div>
 
     <div class="global_grouping">

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -5,7 +5,7 @@
   servers = <%= @servers.to_json.html_safe %>;
 </script>
 
-<div id="dashboard" ng-controller="DashboardCtrl">
+<div id="dashboard" class="row" ng-controller="DashboardCtrl">
   <h1 class="col-lg-12" ng-non-bindable
     ng-class="{fullscreen_title: fullscreenTitle && fullscreen}">
     <%= page_title @dashboard.name %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,10 +42,10 @@
       <div class="<%= container_class %>">
         <div class="content">
            <div class="row">
-            <div class="span12">
-              <%= render 'layouts/messages' %>
-              <%= yield %>
-            </div>
+             <div class="col-md-12">
+               <%= render 'layouts/messages' %>
+               <%= yield %>
+             </div>
           </div>
           <footer>
           </footer>


### PR DESCRIPTION
The visual changes here are fairly minor, but there are a few differences under the hood – I'll list those below.

<h4>Before</h4>
![before](https://cloud.githubusercontent.com/assets/42478/9520103/75d98394-4cc4-11e5-8798-2c6a99221dda.png)

<h4>After</h4>
![after](https://cloud.githubusercontent.com/assets/42478/9520106/78c9cbae-4cc4-11e5-8e59-2b9817928029.png)

#### Changes

* Per-graph popups now have slightly cleaner formatting: inputs and controls use more of the available space.
* Tidied up some of the spacing between elements to be more uniform, same goes for the fullscreen view.
* Slightly improved use of Bootstrap classes like `row` and `col-...`.
* Some whitespace changes - sorry for not keeping these separate.

Please let me know if you'd like me to squash/tidy these commits. I left them separate for now, in case you take particular issue with any of them individually. There's probably more where this came from, but I thought I'd keep it simple for now.

Thanks!

/cc @juliusv @stuartnelson3 @grobie 