### PR TITLE
Documentation updates for dev tools and a simple reverse proxy deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ $ jshint app/assets/javascripts
 ## Deployment
 
 ### Development Mode
+
+You need need to install multiple dependencies for the full development cycle.
+Here is the rundown for Ubuntu 14.04 LTS as a reference. If you run into errors
+with `bundle`, the most likely reason is that the database servers are not
+properly installed with dev headers/libs.
+
+* Node.js
+ * `sudo apt-get install nodejs nodejs-legacy npm`
+* Ruby
+ * `sudo apt-get install ruby-full` ([details](https://www.ruby-lang.org/en/documentation/installation/))
+* MySQL
+ * `sudo apt-get install libmysqlclient-dev` ([details](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/index.html#apt-repo-fresh-install))
+* PostgreSQL
+ * `sudo apt-get install postgresql-9.{3|4} postgresql-server-dev-9.{3|4}` ([details](http://www.postgresql.org/download/linux/))
+* SQLite
+ * `sudo apt-get install sqlite3 libsqlite3-dev` ([details](https://www.sqlite.org/download.html))
+
 Install gems:
 
     bundle
@@ -65,10 +82,11 @@ Run the production server from the bundled environment:
     bin/env bin/bundle exec bin/thin -p $PORT start
 
 ### Deploy with Docker
+
 To deploy PromDash with Docker, use the [prom/promdash](https://registry.hub.docker.com/u/prom/promdash/) Docker image.
 By default, the image will start the [thin webserver](http://code.macournoyer.com/thin/)
 webserver in production mode. To run rake tasks like migrations, you
-can specify any kind of command as parameter to the Docker image.  
+can specify any kind of command as parameter to the Docker image.
 
 #### Super easy quickstart deployment with Docker
 
@@ -76,17 +94,69 @@ The following is a quick-start example for running PromDash with a file-based lo
 
 First, create the SQLite3 database in a shared local Docker volume on the host:
 
-    docker run -v /tmp/prom:/tmp/prom -e DATABASE_URL=sqlite3:/tmp/prom/file.sqlite3 prom/promdash ./bin/rake db:migrate
+    docker run --rm -v /tmp/prom:/tmp/prom \
+           -e DATABASE_URL=sqlite3:/tmp/prom/file.sqlite3 \
+           prom/promdash ./bin/rake db:migrate
 
 Now, we launch PromDash with the database we've just created:
 
-    docker run -p 3000:3000 -v /tmp/prom:/tmp/prom -e DATABASE_URL=sqlite3:/tmp/prom/file.sqlite3 prom/promdash
+    docker run -p 3000:3000 -v /tmp/prom:/tmp/prom \
+           -e DATABASE_URL=sqlite3:/tmp/prom/file.sqlite3 \
+           prom/promdash
+
+You can pass parameters directly to the thin server with:
+
+    docker run -p 3000:4000 -v /tmp/prom:/tmp/prom \
+           -e DATABASE_URL=sqlite3:/tmp/prom/file.sqlite3 \
+           prom/promdash ./bin/thin -a localhost -p 4000 start
 
 ### Deploy behind a reverse proxy
 
 To deploy PromDash behind a reverse proxy you can set a global path prefix
 using the environment variable `PROMDASH_PATH_PREFIX`. Once set all URLs will
 start with the given prefix.
+
+One simple way to secure your Prometheus deployment with authentication is
+running a reverse proxy, Prometheus, and PromDash on the same machine. The goal
+is to have a publicly available deployment for authenticated users via your
+reverse proxy while restricting raw `IP:PORT` access. We won't cover any
+details on how to configure your reverse proxy, as it depends on what you are
+using.
+
+As PromDash executes Prometheus queries directly from the client it is simpler
+to use a single domain. This makes the server side ACL management simpler and
+the client requests already authenticated. 
+
+**Reverse proxy** (e.g. [nginx](http://nginx.org/), [HAProxy](http://www.haproxy.org/))
+* Set up single domain.
+ * Route `http(s)://dash.example.com/dash` to backend `localhost:3000`
+ * Route `http(s)://dash.example.com/prom` to backend `localhost:9090`
+* Configure the same ACL, e.g. HTTP basic auth for both backends.
+
+**Run Prometheus** with binding only to localhost to restrict direct external
+access over the network that would circumvent your authentication. Remember to
+pass the path portion in `-web.external-url`. Example for Docker:
+([full reference](http://prometheus.io/docs/introduction/install/#using-docker))
+
+    docker run -p 127.0.0.1:9090:9090 -v /prometheus-data \
+           prom/prometheus -config.file=/prometheus-data/prometheus.yml \
+                           -web.external-url "http://dash.example.com/prom"
+
+**Run PromDash** in a similar fashion. Once PromDash is running add a
+Prometheus server with `http://dash.example.com/prom/` in the web UI at
+`http://dash.example.com/dash`.
+
+    docker run -p 127.0.0.1:3000:3000 -v /tmp/prom:/tmp/prom \
+           -e DATABASE_URL=sqlite3:/tmp/prom/file.sqlite3 \
+           -e PROMDASH_PATH_PREFIX=/dash \
+           prom/promdash
+
+Finally check that your reverse proxy is working as expected by visiting
+`dash.example.com/dash` and `dash.example.com/prom`. Both should prompt you for
+credentials, e.g. HTTP basic auth. You can use a Chrome incognito tab to force
+authentication. Next visit the public facing IP address on the ports
+`<IP>:3000/dash` and `<IP>:9090/prom` to verify they are in fact giving a page
+load error.
 
 ### Deployment Checklist
 


### PR DESCRIPTION
I commented on a issue that this aspect of prometheus and promdash is not covered very well. I'm hoping new prometheus users like me will benefit from it written down somewhere. My biggest hurdle in even trying out prometheus for a long time was the lack of clear docs for how to restrict access to the monitoring.

As @juliusv noted in the issue the projects focus has not been on this kind of "small scale" setup you roll on your own, but for more experienced people and private clusters. I believe many small companies might benefit in what I wrote down as its fairly simple to setup. This is for small deployments as everything is running on a single machine and means you cant easily add more prometheus servers. You can by doing more reverse proxy magic and esp. once the basic auth in the server URL is implemented.

I can also look into making a more in detail doc page into https://github.com/prometheus/docs with all details and configs for HAProxy as that is what I know how to use now. If you think its a good idea.

If the dev tool install part is too much detail in your opinion, I made it a separate commit so its easy to revert.

Feel free to comment on any typos or bad wording, I'll fix them up.