### PR TITLE
A more descriptive title for the 'Remove dashboards' action

### DIFF
--- a/app/views/directories/_form.html.erb
+++ b/app/views/directories/_form.html.erb
@@ -17,7 +17,7 @@
   </div>
 
   <% if @directory.dashboards.present? %>
-    <h3>Remove dashboards</h3>
+    <h3>Uncheck dashboards to remove</h3>
   <% end %>
   <% @directory.dashboards.each do |dashboard|%>
     <div class="form-group">


### PR DESCRIPTION
By default, all the dashboards are checked, so it kinda looks like it’s gonna remove all my dashboards when I save, while in fact I have to uncheck whatever I want to be removed.

@juliusv @stuartnelson3 