### PR TITLE
Override Bootstrap's 0-padding for table cells.

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -13,3 +13,9 @@ body { padding-top: 60px; }
   font-weight: bold;
   padding: 8px 10px 10px 10px;
 }
+
+// Bootstrap's default is 0. This rule ensures that table cells (e.g. when
+// defining annotation tags or dashboard variables) are not "glued" together.
+th, td {
+  padding: 1px;
+}


### PR DESCRIPTION
The recent bootstrap upgrade "glued" together table cells when defining
annotation tags or dashboard variables by setting a 0-padding on td and
th.

Old:

![bad](https://cloud.githubusercontent.com/assets/538008/9961754/944713ae-5e22-11e5-8df8-56e62adf62de.png)

New:

![good](https://cloud.githubusercontent.com/assets/538008/9961762/9b8b4428-5e22-11e5-9df8-1306e7c3eddd.png)
