### PR TITLE
Upgrade capybara and selenium-webdriver to latest versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,10 +19,10 @@ group :test, :development do
   gem 'sinatra'
   gem 'pry'
   gem 'rspec-rails', "~> 3.0.0.beta2"
-  gem 'selenium-webdriver'
+  gem 'selenium-webdriver', '~> 2.47.1'
   gem 'database_cleaner'
   gem 'launchy'
-  gem 'capybara', "~> 2.3.0"
+  gem 'capybara', '~> 2.5.0'
   gem 'rake' # for .travis.yml
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,13 +32,13 @@ GEM
     addressable (2.3.5)
     arel (5.0.1.20140414130214)
     builder (3.2.2)
-    capybara (2.3.0)
+    capybara (2.5.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    childprocess (0.5.3)
+    childprocess (0.5.6)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.0.9)
     daemons (1.1.9)
@@ -54,7 +54,7 @@ GEM
     factory_girl_rails (4.4.1)
       factory_girl (~> 4.4.0)
       railties (>= 3.0.0)
-    ffi (1.9.5)
+    ffi (1.9.10)
     hike (1.2.3)
     i18n (0.7.0)
     jbuilder (1.5.2)
@@ -72,12 +72,12 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.4.3)
-    mini_portile (0.6.0)
+    mini_portile (0.6.2)
     minitest (5.5.1)
     multi_json (1.10.1)
     mysql2 (0.3.14)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     pg (0.18.1)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
@@ -127,7 +127,7 @@ GEM
       rspec-mocks (= 3.0.0.beta2)
       rspec-support (= 3.0.0.beta2)
     rspec-support (3.0.0.beta2)
-    rubyzip (1.1.6)
+    rubyzip (1.1.7)
     sass (3.2.19)
     sass-rails (4.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -137,7 +137,7 @@ GEM
     sdoc (0.3.20)
       json (>= 1.1.3)
       rdoc (~> 3.10)
-    selenium-webdriver (2.43.0)
+    selenium-webdriver (2.47.1)
       childprocess (~> 0.5)
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
@@ -172,7 +172,7 @@ GEM
     uglifier (2.2.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
-    websocket (1.2.1)
+    websocket (1.2.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -181,7 +181,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
-  capybara (~> 2.3.0)
+  capybara (~> 2.5.0)
   database_cleaner
   entypo-rails
   factory_girl_rails
@@ -197,7 +197,7 @@ DEPENDENCIES
   rspec-rails (~> 3.0.0.beta2)
   sass-rails (~> 4.0.4)
   sdoc
-  selenium-webdriver
+  selenium-webdriver (~> 2.47.1)
   sinatra
   sqlite3
   therubyracer


### PR DESCRIPTION
This makes the tests pass on my local machine, because I was running a newer version of Firefox (40.0.2).

In past projects, I've had to keep these versions up to date fairly frequently. This is because Firefox auto-upgrades to a newer version, and breaks compatibility with the gems that drive the browser for tests.

/cc @juliusv @stuartnelson3 