### PR TITLE
fix errors in widget pages

### DIFF
--- a/app/assets/javascripts/angular/resources/shared_graph_behavior.js
+++ b/app/assets/javascripts/angular/resources/shared_graph_behavior.js
@@ -233,7 +233,7 @@ angular.module("Prometheus.services").factory("SharedGraphBehavior", ["$http", "
 
     function clearScreen() {
       $scope.$apply(function() {
-        $scope.closeCloneControls();
+        ($scope.closeCloneControls || function(){})();
         $scope.$broadcast('closeTabs');
         $scope.showDashboardSettings = false;
         $scope.showPermalink = false;

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -2,7 +2,6 @@
   dashboardData = <%= @dashboard.dashboard_json ? @dashboard.dashboard_json.html_safe : '{}' %>;
   dashboardName = "<%= @dashboard.name %>";
   directoryName = "<%= @directoryName %>";
-  dashboardURL = "<%= Rails.configuration.path_prefix %>";
   servers = <%= @servers.to_json.html_safe %>;
   profile = "<%= @dashboard_profile %>";
 </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,9 @@
     <% end %>
     <%= csrf_meta_tags %>
     <base href="/">
+    <script type="text/javascript">
+      dashboardURL = "<%= Rails.configuration.path_prefix %>";
+    </script>
   </head>
   <body>
 

--- a/app/views/layouts/single_widget.html.erb
+++ b/app/views/layouts/single_widget.html.erb
@@ -8,6 +8,10 @@
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
+    <base href="/">
+    <script type="text/javascript">
+      dashboardURL = "<%= Rails.configuration.path_prefix %>";
+    </script>
   </head>
   <body>
     <%= yield %>


### PR DESCRIPTION
widget pages were failing to load annotations
because of a missing variable, which caused the
graph to become unresponsive

additionally, widget pages attempted to call a
function that did not exist.

@juliusv 

to test: create a widget page, verify no errors occur in console on load and hover detail exists. open a widget tab, hit "esc" to close, verify no error occurs in console.