### PR TITLE
fix loading widgets that rely on profiles

### DIFF
--- a/app/assets/javascripts/angular/controllers/dashboard_ctrl.js.erb
+++ b/app/assets/javascripts/angular/controllers/dashboard_ctrl.js.erb
@@ -12,6 +12,7 @@ angular.module("Prometheus.controllers")
             "Palettes",
             "AnnotationRefresher",
             "DashboardVariables",
+            "Profile",
             function($scope,
                      $window,
                      $http,
@@ -24,7 +25,8 @@ angular.module("Prometheus.controllers")
                      ModalService,
                      Palettes,
                      AnnotationRefresher,
-                     DashboardVariables) {
+                     DashboardVariables,
+                     Profile) {
 
   $window.onresize = function() {
     $scope.$broadcast('redrawGraphs');
@@ -69,35 +71,7 @@ angular.module("Prometheus.controllers")
   $scope.globalConfig.palette = $scope.globalConfig.palette || 'colorwheel';
   $scope.globalConfig.resolution = $scope.globalConfig.resolution || 4;
   $scope.globalConfig.profiles = $scope.globalConfig.profiles || {};
-  $scope.parsedProfiles = unmarshal($scope.globalConfig.profiles);
-
-  function Profile(name, variablePairs) {
-    this.name = name;
-    this.variablePairs = variablePairs;
-  }
-
-  function marshal(profiles) {
-    var o = {};
-
-    for (var i = 0; i < profiles.length; i++) {
-      var p = profiles[i];
-      o[p.name] = p.variablePairs;
-    }
-
-    return o;
-  }
-
-  function unmarshal(jsonProfiles) {
-    var a = [];
-
-    for (var name in jsonProfiles) {
-      var variablePairs = jsonProfiles[name];
-      var p = new Profile(name, variablePairs);
-      a.push(p);
-    }
-
-    return a;
-  }
+  $scope.parsedProfiles = Profile.unmarshal($scope.globalConfig.profiles);
 
   $scope.saveDashboard = function() {
     $scope.saving = true;
@@ -111,7 +85,7 @@ angular.module("Prometheus.controllers")
   $scope.addProfile = function() {
     var n = $scope.parsedProfiles.length;
     var p = "Profile" + n;
-    var newProfile = new Profile(p, [])
+    var newProfile = Profile.new(p, [])
     $scope.parsedProfiles.push(newProfile);
 
     if (n > 0) {
@@ -141,6 +115,7 @@ angular.module("Prometheus.controllers")
     $scope.activeProfileName = "";
     if (profile) {
       $scope.activeProfileName = profile.name;
+      window.activeProfileName = profile.name;
     }
 
     $scope.mergedVars = DashboardVariables.mergeToObject($scope.vars, profile.variablePairs);
@@ -391,7 +366,7 @@ angular.module("Prometheus.controllers")
   };
 
   function buildDashboardJSON() {
-    $scope.globalConfig.profiles = marshal($scope.parsedProfiles);
+    $scope.globalConfig.profiles = Profile.marshal($scope.parsedProfiles);
 
     return {
       'dashboard': {

--- a/app/assets/javascripts/angular/controllers/single_widget_ctrl.js
+++ b/app/assets/javascripts/angular/controllers/single_widget_ctrl.js
@@ -1,4 +1,4 @@
-angular.module("Prometheus.controllers").controller('SingleWidgetCtrl', ["$window", "$timeout", "$scope", "$http", "URLConfigDecoder", "GraphRefresher", "ServersByIDObject", "FullScreenAspectRatio", "ThemeManager", "SharedGraphBehavior", function($window, $timeout, $scope, $http, URLConfigDecoder, GraphRefresher, ServersByIDObject, FullScreenAspectRatio, ThemeManager, SharedGraphBehavior) {
+angular.module("Prometheus.controllers").controller('SingleWidgetCtrl', ["$window", "$timeout", "$scope", "$http", "URLConfigDecoder", "GraphRefresher", "ServersByIDObject", "FullScreenAspectRatio", "ThemeManager", "SharedGraphBehavior", "Profile", "DashboardVariables", function($window, $timeout, $scope, $http, URLConfigDecoder, GraphRefresher, ServersByIDObject, FullScreenAspectRatio, ThemeManager, SharedGraphBehavior, Profile, DashboardVariables) {
   var graphBlob = URLConfigDecoder(window.blob);
   $scope.widgets = [graphBlob.widget];
   $scope.servers = servers;
@@ -8,6 +8,14 @@ angular.module("Prometheus.controllers").controller('SingleWidgetCtrl', ["$windo
   $scope.globalConfig.aspectRatio = FullScreenAspectRatio();
   ThemeManager.setTheme($scope.globalConfig.theme);
   SharedGraphBehavior($scope, $scope.globalConfig);
+
+  if (graphBlob.activeProfileName) {
+    var profile = $scope.globalConfig.profiles[graphBlob.activeProfileName];
+    if (profile) {
+      var parsedProfile = Profile.unmarshal([profile])[0];
+      $scope.globalConfig.vars = DashboardVariables.mergeToObject($scope.globalConfig.vars, parsedProfile.variablePairs);
+    }
+  }
 
   $window.onresize = function() {
     $scope.$apply(function() {

--- a/app/assets/javascripts/angular/services/profile.js
+++ b/app/assets/javascripts/angular/services/profile.js
@@ -1,0 +1,35 @@
+angular.module("Prometheus.services").factory('Profile', function() {
+  function Profile (name, variablePairs) {
+    this.name = name;
+    this.variablePairs = variablePairs;
+  }
+
+  return {
+    new: function(name, variablePairs) {
+      return new Profile(name, variablePairs);
+    },
+
+    marshal: function(profiles) {
+      var o = {};
+
+      for (var i = 0; i < profiles.length; i++) {
+        var p = profiles[i];
+        o[p.name] = p.variablePairs;
+      }
+
+      return o;
+    },
+
+    unmarshal: function(jsonProfiles) {
+      var a = [];
+
+      for (var name in jsonProfiles) {
+        var variablePairs = jsonProfiles[name];
+        var p = new Profile(name, variablePairs);
+        a.push(p);
+      }
+
+      return a;
+    }
+  };
+});

--- a/app/assets/javascripts/angular/services/shared_widget_setup.js
+++ b/app/assets/javascripts/angular/services/shared_widget_setup.js
@@ -24,6 +24,11 @@ return function($scope) {
     var graphBlob = {};
     graphBlob.widget = $scope.graph;
     graphBlob.globalConfig = dashboardData.globalConfig;
+
+    if (window.activeProfileName) {
+      graphBlob.activeProfileName = activeProfileName;
+    }
+
     WidgetLinkHelper
       .createLink({
          encoded_url: URLHashEncoder(graphBlob),


### PR DESCRIPTION
break out graphs will now load variables from the correct profile if one was selected

@samstarling check that this works for dashboards with and without profiles :)