### PR TITLE
Send credentials with XMLHttpRequests

### DIFF
--- a/app/assets/javascripts/angular/app.js
+++ b/app/assets/javascripts/angular/app.js
@@ -19,6 +19,7 @@ angular.module("Prometheus",
   if ($location.hash()[0] === "?") {
     $location.url($location.path() + $location.hash());
   }
-}]).config(['$locationProvider', function($locationProvider) {
+}]).config(['$locationProvider', '$httpProvider', function($locationProvider, $httpProvider) {
   $locationProvider.html5Mode(true);
+  $httpProvider.defaults.withCredentials = true;
 }]);


### PR DESCRIPTION
In cases where Prometheus instances run behind authenticating proxies,
cookies or Basic authentication may be required for requests from
PromDash too.

I'm no web dev, this change was devised purely by parroting the Angular docs.
Seems to work on our deployment though.

@stuartnelson3 , you probably have a clue, though, and I'd appreciate it if you could take a look. Thanks. =)