### PR TITLE
fix creation of first dashboard

### DIFF
--- a/app/assets/javascripts/angular/controllers/dashboard_ctrl.js.erb
+++ b/app/assets/javascripts/angular/controllers/dashboard_ctrl.js.erb
@@ -323,6 +323,10 @@ angular.module("Prometheus.controllers")
       $scope.dashboardForClone = payload.data.dashboards.filter(function(d) {
         return d.name == dashboardName;
       })[0] || payload.data.dashboards[0];
+      if (!$scope.dashboardForClone) {
+        $scope.dashboardForClone = {};
+        return;
+      }
       $scope.queryDashboard();
     });
   };


### PR DESCRIPTION
first dashboard creation was failing due to no
dashboards being returned from the
"dashboardToClone" function call.

this only affected users with no other existing dashboards.

fixes #474 