### PR TITLE
Display label in hoverDetail if label is from format string

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -43,6 +43,7 @@ angular.module("Prometheus.directives").directive('graphChart', [
               })[0];
               if ((lst || {}).name) {
                 s.name = VariableInterpolator(lst.name, s.labels);
+                s.nameIsFormatted = true;
               }
               s.name = HTMLEscaper(s.name);
             }
@@ -356,10 +357,11 @@ angular.module("Prometheus.directives").directive('graphChart', [
         var hoverDetail = new Rickshaw.Graph.HoverDetail({
           graph: rsGraph,
           formatter: function(series, x, y) {
+            var name = series.nameIsFormatted? '<span class="name">' + series.name + '</span><br>' : '';
             var date = '<span class="date">' + new Date(x * 1000).toUTCString() + '</span>';
             var swatch = '<span class="detail_swatch" style="background-color: ' + series.color + '"></span>';
             var content = swatch + (series.labels.__name__ || 'value') + ": <strong>" + y + '</strong>';
-            return date + '<br>' + content + '<br>' + renderLabels(series.labels);
+            return name + date + '<br>' + content + '<br>' + renderLabels(series.labels);
           },
           onRender: function() {
             var dot = this.graph.element.querySelector('.dot');

--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -357,10 +357,16 @@ angular.module("Prometheus.directives").directive('graphChart', [
         var hoverDetail = new Rickshaw.Graph.HoverDetail({
           graph: rsGraph,
           formatter: function(series, x, y) {
-            var name = series.nameIsFormatted? '<span class="name">' + series.name + '</span><br>' : '';
-            var date = '<span class="date">' + new Date(x * 1000).toUTCString() + '</span>';
             var swatch = '<span class="detail_swatch" style="background-color: ' + series.color + '"></span>';
-            var content = swatch + (series.labels.__name__ || 'value') + ": <strong>" + y + '</strong>';
+            var name, content;
+            if (series.nameIsFormatted) {
+                name = swatch + '<span class="name">' + series.name + '</span><br>';
+                content = (series.labels.__name__ || 'value') + ": <strong>" + y + '</strong>';
+            } else {
+                name = '';
+                content = swatch + (series.labels.__name__ || 'value') + ": <strong>" + y + '</strong>';
+            }
+            var date = '<span class="date">' + new Date(x * 1000).toUTCString() + '</span>';
             return name + date + '<br>' + content + '<br>' + renderLabels(series.labels);
           },
           onRender: function() {

--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -208,6 +208,14 @@ $light-secondary-background: #f0f0f0;
       padding-right: 7px;
     }
   }
+
+  .detail_swatch {
+    display: inline-block;
+    height: 7px;
+    width: 10px;
+    border-radius: 2px;
+    margin-right: 5px;
+  }
 }
 
 $light-background: #f5f5f5;


### PR DESCRIPTION
This allows for human friendly labels to be shown in charts with
many series (so showing the legend would take too much space).

Similar to #368, but with a more limited scope

E.g. with custom format string "test!":
[![https://gyazo.com/0b89ff00a2eb3ed983980bb8d6ccd4c6](https://i.gyazo.com/0b89ff00a2eb3ed983980bb8d6ccd4c6.png)](https://gyazo.com/0b89ff00a2eb3ed983980bb8d6ccd4c6)

E.g. without a format string:
[![https://gyazo.com/aa63ccceb29b2206578605dd506c9f03](https://i.gyazo.com/aa63ccceb29b2206578605dd506c9f03.png)](https://gyazo.com/aa63ccceb29b2206578605dd506c9f03)