### PR TITLE
Highlight the background of future graph sections

### DIFF
--- a/app/assets/javascripts/angular/directives/graph_chart.js
+++ b/app/assets/javascripts/angular/directives/graph_chart.js
@@ -311,6 +311,9 @@ angular.module("Prometheus.directives").directive('graphChart', [
           height: calculateGraphHeight($legend)
         });
         rsGraph.series.legend = legend;
+        rsGraph.onUpdate(function () {
+          highlightFuture(rsGraph);
+        });
         rsGraph.render();
 
         AnnotationRefresher.refresh(scope.graphSettings.tags, scope.graphSettings.range, scope.graphSettings.endTime, scope.vars)
@@ -380,6 +383,27 @@ angular.module("Prometheus.directives").directive('graphChart', [
             }
           },
         });
+      }
+
+      function highlightFuture(rsGraph) {
+        var svg = d3.select(rsGraph.element).select('svg');
+        var left = rsGraph.x((new Date()).getTime() / 1000);
+        var width = rsGraph.x.range()[1];
+
+        svg.select('.highlight-future').remove();
+        if (left < 1) {
+          left = 0;
+        }
+        if (left < width) {
+          svg.append('rect')
+             .attr('class', 'highlight-future')
+             .attr('y', 0)
+             .attr('height', '100%')
+             .style('fill', 'yellow')
+             .style('opacity', '0.1')
+             .attr('x', left)
+             .attr('width', width - left);
+        }
       }
 
       function createYAxis2(graph, tickFormat, scale) {


### PR DESCRIPTION
This is a simple usability aid that allows users to better orient
themself in time.  This is especially useful when users are not
familiar with UTC times.

Eg.  dark graph:

[![https://gyazo.com/b58bf5dc1f102d35691367296017768b](https://i.gyazo.com/b58bf5dc1f102d35691367296017768b.png)](https://gyazo.com/b58bf5dc1f102d35691367296017768b)

Eg.  light graph

[![https://gyazo.com/c69a04da4976cf8e55eaff3afa12a68a](https://i.gyazo.com/c69a04da4976cf8e55eaff3afa12a68a.png)](https://gyazo.com/c69a04da4976cf8e55eaff3afa12a68a)