### PR TITLE
Add redirects for users transitioning to grafana

### DIFF
--- a/app/assets/stylesheets/dashboards.css.scss
+++ b/app/assets/stylesheets/dashboards.css.scss
@@ -782,3 +782,11 @@ hr {
   right: 30px;
 }
 
+.small-text {
+  margin: 10px 0;
+  display: block;
+}
+
+.alert-spacing {
+  margin: 15px 15px 0;
+}

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -14,6 +14,9 @@ class DashboardsController < ApplicationController
   # GET /dashboards/1
   # GET /dashboards/1.json
   def show
+    if @dashboard.hard_redirect && !@dashboard.link.blank?
+      redirect_to @dashboard.link
+    end
     respond_to do |format|
       format.html do
         @dashboard_profile = params[:profile]
@@ -128,6 +131,6 @@ class DashboardsController < ApplicationController
       ServerTransformer.transform(dashboard_json)
       params[:dashboard][:dashboard_json] = JSON.generate(dashboard_json)
     end
-    params.require(:dashboard).permit(:name, :dashboard_json, :slug, :directory_id)
+    params.require(:dashboard).permit(:name, :dashboard_json, :slug, :directory_id, :link, :hard_redirect)
   end
 end

--- a/app/views/dashboards/_form.html.erb
+++ b/app/views/dashboards/_form.html.erb
@@ -25,6 +25,21 @@
     </div>
   <% end %>
 
+  <div class="field form-group">
+    <%= f.label :link %><br>
+    <%= f.text_field :link, class: "form-control input-small" %>
+  </div>
+
+  <div class="form-group">
+      <%= f.label "Hard redirect"  %><br>
+    <div class="checkbox">
+      <%= f.label :hard_redirect do %>
+        <%= f.check_box :hard_redirect, class: "checkbox" %>
+        Redirect users to this link
+      <% end %>
+    </div>
+  </div>
+
   <div class="form-group">
     <%= f.label :directory %><br>
     <%= select_tag "dashboard[directory_id]",

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -8,7 +8,7 @@
 
 <div id="dashboard" class="row" ng-controller="DashboardCtrl">
   <% if !@dashboard.link.blank? %>
-    <div class="alert alert-info alert-spacing" role="alert"><strong>This dashboard has a link<strong>: <%= link_to(@dashboard.link, @dashboard.link) %></div>
+    <div class="alert alert-info alert-spacing" role="alert"><strong>Heads up! This dashboard has been moved to <strong><%= link_to(@dashboard.link, @dashboard.link) %></div>
   <% end %>
   <h1 class="col-lg-12" ng-non-bindable
     ng-class="{fullscreen_title: fullscreenTitle && fullscreen}">

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -7,6 +7,9 @@
 </script>
 
 <div id="dashboard" class="row" ng-controller="DashboardCtrl">
+  <% if !@dashboard.link.blank? %>
+    <div class="alert alert-info alert-spacing" role="alert"><strong>This dashboard has a link<strong>: <%= link_to(@dashboard.link, @dashboard.link) %></div>
+  <% end %>
   <h1 class="col-lg-12" ng-non-bindable
     ng-class="{fullscreen_title: fullscreenTitle && fullscreen}">
     <%= page_title @dashboard.name %>
@@ -233,7 +236,7 @@
         <th colspan="4">Template Variables</th>
       </tr>
       <tr>
-        <th ng-if="activeProfileName" colspan="4"><small>WARNING: Profile variables take precedence over template variables</small></th>
+        <th ng-if="activeProfileName" colspan="4"><small class="small-text">WARNING: Profile variables take precedence over template variables</small></th>
       </tr>
 
       <tr ng-show="vars.length == 0">

--- a/app/views/directories/_dashboards_table.html.erb
+++ b/app/views/directories/_dashboards_table.html.erb
@@ -3,7 +3,7 @@
     <tr>
       <td class="dashboard_name"><%= link_to dashboard.name, dashboard_slug_path(dashboard.slug) %></td>
       <td>
-        <%= link_to 'Rename', edit_dashboard_path(dashboard) %>
+        <%= link_to 'Edit', edit_dashboard_path(dashboard) %>
         &nbsp;&nbsp;
         <%= link_to 'Clone', clone_dashboard_path(id: dashboard.id) %>
         &nbsp;&nbsp;

--- a/db/migrate/20160609120620_add_link_to_dashboard.rb
+++ b/db/migrate/20160609120620_add_link_to_dashboard.rb
@@ -1,0 +1,5 @@
+class AddLinkToDashboard < ActiveRecord::Migration
+  def change
+    add_column :dashboards, :link, :string, default: "", null: false
+  end
+end

--- a/db/migrate/20160609130416_add_redirect_checkbox_to_dashboard.rb
+++ b/db/migrate/20160609130416_add_redirect_checkbox_to_dashboard.rb
@@ -1,0 +1,5 @@
+class AddRedirectCheckboxToDashboard < ActiveRecord::Migration
+  def change
+    add_column :dashboards, :hard_redirect, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150814142427) do
+ActiveRecord::Schema.define(version: 20160609130416) do
 
   create_table "dashboards", force: true do |t|
     t.string   "name"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 20150814142427) do
     t.string   "slug"
     t.integer  "directory_id"
     t.boolean  "permalink",      default: false
+    t.string   "link",           default: "",    null: false
+    t.boolean  "hard_redirect",  default: false, null: false
   end
 
   add_index "dashboards", ["directory_id"], name: "index_dashboards_on_directory_id"

--- a/spec/features/dashboards/dashboards_spec.rb
+++ b/spec/features/dashboards/dashboards_spec.rb
@@ -123,7 +123,7 @@ feature "Dashboard", js: true do
 
     describe "the name" do
       scenario "valid" do
-        click_link('Rename')
+        click_link('Edit')
         find("#dashboard_name").set("some other name")
         click_button("Update Dashboard")
         expect(page).to have_content(/successfully updated/)
@@ -131,7 +131,7 @@ feature "Dashboard", js: true do
       end
 
       scenario "invalid" do
-        click_link('Rename')
+        click_link('Edit')
         find("#dashboard_name").set("")
         click_button("Update Dashboard")
         expect(page).to have_content(/error/)
@@ -141,7 +141,7 @@ feature "Dashboard", js: true do
 
     describe "the slug" do
       scenario "valid" do
-        click_link('Rename')
+        click_link('Edit')
         find("#dashboard_slug").set("valid-slug-name")
         click_button("Update Dashboard")
         expect(page).to have_content(/successfully updated/)
@@ -149,7 +149,7 @@ feature "Dashboard", js: true do
       end
 
       scenario "invalid" do
-        click_link('Rename')
+        click_link('Edit')
         find("#dashboard_slug").set("invalid slug name")
         click_button("Update Dashboard")
         expect(page).to have_content(/error/)


### PR DESCRIPTION
To aid in the transition from promdash to grafana:

- Add a `link` and `hard_redirect` field to dashboard
- If link is filled out, show an informational header on the dashboard page
- If the link is filled out and hard-redirect is selected, redirect to the link chosen
- If hard-redirect is selected but there is no link, no redirect occurs

@grobie 