### PR TITLE
Restrict log scale domain min value to 1 to prevent NaN.

### DIFF
--- a/app/assets/javascripts/angular/services/y_axis_utilities.js
+++ b/app/assets/javascripts/angular/services/y_axis_utilities.js
@@ -13,7 +13,7 @@ angular.module("Prometheus.services").factory('YAxisUtilities', [function() {
   }
   return {
     setLogScale: function(min, max) {
-      logScale = extendScale(d3.scale.log().domain([min, max]));
+      logScale = extendScale(d3.scale.log().domain([1, max]));
       return logScale;
     },
     setLinearScale: function(min, max) {


### PR DESCRIPTION
Log scale may be very convenient. However, we happen to have some values at 0.This should not be a problem since this is a log scale (ie just a way to display).

However, if we have a 0 value, the complete series is erased, replaced by "NaN". The trivial workaround is to put "+1" on the query (urk).

This commit reduces the scale domain to [1, max] and prevents this bug. The series is now considered as "no value" only on dots where the value is 0 (interrupted curve) which is better than nothing.